### PR TITLE
print the missingval to IO

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -3,7 +3,7 @@ function DD.show_after(io::IO, mime::MIME"text/plain", A::AbstractRaster)
 
     if missingval(A) !== nothing
         printstyled(io, "with missingval: "; color=:light_black)
-        print(string(missingval(A)), "\n")
+        print(io, string(missingval(A)), "\n")
     end
     if parent(A) isa DiskArrays.AbstractDiskArray 
         if parent(A) isa FileArray 


### PR DESCRIPTION
The missingval itself was not being printed to io  in `show()`, leading to funny printing during things like docs building with Documenter. I think this simple patch should fix it.