### PR TITLE
add skipmissing for missingval

### DIFF
--- a/src/Rasters.jl
+++ b/src/Rasters.jl
@@ -97,6 +97,7 @@ const RasterStackOrArray = Union{AbstractRasterStack,AbstractRaster}
 const RasterSeriesOrStack = Union{AbstractRasterSeries,AbstractRasterStack}
 
 include("utils.jl")
+include("skipmissing.jl")
 include("polygon_ops.jl")
 include("table_ops.jl")
 include("create.jl")

--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -1,0 +1,49 @@
+
+function Base.skipmissing(itr::Raster)
+    if ismissing(missingval(itr))
+        Base.SkipMissing(itr)
+    else
+        SkipMissingVal(itr)
+    end
+end
+
+struct SkipMissingVal{T}
+    x::T
+end
+Base.IteratorSize(::Type{<:SkipMissingVal}) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{SkipMissingVal{T}}) where {T} = Base.IteratorEltype(T)
+Base.eltype(::Type{SkipMissingVal{T}}) where {T} = Base.nonmissingtype(eltype(T))
+missingval(itr::SkipMissingVal) = missingval(itr.x)
+
+function Base.iterate(itr::SkipMissingVal, state...)
+    y = iterate(itr.x, state...)
+    y === nothing && return nothing
+    item, state = y
+    # We check for both `missing` and the raster `missingval`
+    # Mostly the compiler should elide the `missing` check?
+    while _missing(item, itr)
+        y = iterate(itr.x, state)
+        y === nothing && return nothing
+        item, state = y
+    end
+    item, state
+end
+
+_missing(x, itr) = x === missingval(itr) || x === missing
+
+Base.IndexStyle(::Type{<:SkipMissingVal{T}}) where {T} = IndexStyle(T)
+Base.eachindex(itr::SkipMissingVal) =
+    Iterators.filter(i -> !_missing(@inbounds(itr.x[i]), itr), eachindex(itr.x))
+Base.keys(itr::SkipMissingVal) =
+    Iterators.filter(i -> !_missing(@inbounds(itr.x[i]), itr), keys(itr.x))
+@propagate_inbounds function Base.getindex(itr::SkipMissingVal, I...)
+    v = itr.x[I...]
+    _missing(v, itr) && throw(MissingException("the value at index $I is the raster missingval"))
+    v
+end
+
+function Base.show(io::IO, s::SkipMissingVal)
+    print(io, "skipmissing(")
+    show(io, s.x)
+    print(io, ')')
+end

--- a/test/array.jl
+++ b/test/array.jl
@@ -59,3 +59,19 @@ end
     @test occursin("Y", sh)
     @test occursin("X", sh)
 end
+
+@testset "skipmissing uses missingval" begin
+    raster = Raster([NaN 1.0; 2.0 NaN], (X, Y); missingval=NaN)
+    @test collect(skipmissing(raster)) == [2.0, 1.0]
+    @test collect(keys(skipmissing(raster))) == [CartesianIndex(2, 1), CartesianIndex(1, 2)]
+    @test collect(eachindex(skipmissing(raster))) == [2, 3]
+    @test_throws MissingException skipmissing(raster)[1]
+    @test skipmissing(raster)[2] == 2.0
+    # It skips actual missing values as well
+    mraster = Raster([NaN 1.0; missing NaN], (X, Y); missingval=NaN)
+    @test collect(skipmissing(mraster)) == [1.0]
+    @test collect(keys(skipmissing(mraster))) == [CartesianIndex(1, 2)]
+    @test collect(eachindex(skipmissing(mraster))) == [3]
+    @test skipmissing(mraster)[3] == 1.0
+    @test_throws MissingException skipmissing(mraster)[2]
+end


### PR DESCRIPTION
Defines `skipmissing` on `Raster` to also skip `missingval`. This should be a lot faster than `skipmissing(replace_missing(raster))`.

Partly resolve #229 