### PR TITLE
compare missingval by value

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -591,6 +591,7 @@ replace_missing
 reproject
 setcrs
 setmappedcrs
+skipmissing
 slice
 subset
 trim

--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -1,4 +1,8 @@
+"""
+    skipmissing(itr::Raster)
 
+Returns an iterable over the elements in a `Raster` object, skipping any values equal to either the `missingval` or `missing`.
+"""
 function Base.skipmissing(itr::Raster)
     if ismissing(missingval(itr))
         Base.SkipMissing(itr)
@@ -29,7 +33,14 @@ function Base.iterate(itr::SkipMissingVal, state...)
     item, state
 end
 
-_missing(x, itr) = x === missingval(itr) || x === missing
+_missing(x, itr) = ismissing(x) || x == missingval(itr)  # mind the order, as comparison with missing returns missing
+function _missing(x::AbstractFloat, itr)
+    if isnan(missingval(itr))
+        return ismissing(x) || isnan(x)
+    else
+        return ismissing(x) || x == missingval(itr)
+    end
+end
 
 Base.IndexStyle(::Type{<:SkipMissingVal{T}}) where {T} = IndexStyle(T)
 Base.eachindex(itr::SkipMissingVal) =

--- a/test/array.jl
+++ b/test/array.jl
@@ -93,6 +93,12 @@ end
     @test collect(eachindex(skipmissing(mraster))) == [3]
     @test skipmissing(mraster)[3] == 1.0
     @test_throws MissingException skipmissing(mraster)[2]
+
+    r = Raster(ones(Int16, 8, 8), (X,Y); missingval = Int16(-9999))
+    r[1:4, 1:4] .= -9999
+    r = float.(r)
+    @test !(missingval(r) in skipmissing(r))
+    @test length(collect(skipmissing(r))) == 48
 end
 
 @testset "table" begin


### PR DESCRIPTION
Here comes the PR. This fixes my use case. The drawback is the explicit check for NaN I introduced. This means that NaN values that were accidentally created in the input to skipmissing could be filtered out unintentionally.

By the way: Why not use the builtin generator?
```julia
Base.skipmissing(r::Raster) = (v for v in r if !(ismissing(v) || isnan(v) || v == missingval(r))))
```