### PR TITLE
add `kw...` to ncdatasets write

### DIFF
--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -91,7 +91,7 @@ from other [`AbstractRaster`](@ref) @types is ignored.
 
 Keywords are passed to `NCDatasets.defVar`.
 
-    - `fillvalue`: A value filled in the NetCDF file to indicate missing data. It
+- `fillvalue`: A value filled in the NetCDF file to indicate missing data. It
     will be stored in the `_FillValue` attribute.
 
     - `chunksizes`: Vector integers setting the chunk size. The total size of a

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -87,7 +87,26 @@ Write an NCDstack to a single netcdf file, using NCDatasets.jl.
 Currently `Metadata` is not handled for dimensions, and `Metadata`
 from other [`AbstractRaster`](@ref) @types is ignored.
 
-`kw...`: see keyword arguments in [`NCDataset.defVar`].
+# Arguments:
+- `kw...`: keyword arguments passed to [`NCDataset.defVar`].
+
+    •  `fillvalue`: A value filled in the NetCDF file to indicate missing data. It
+    will be stored in the `_FillValue` attribute.
+
+    •  `chunksizes`: Vector integers setting the chunk size. The total size of a
+    chunk must be less than 4 GiB.
+
+    •  `deflatelevel`: Compression level: 0 (default) means no compression and 9
+    means maximum compression. Each chunk will be compressed individually.
+
+    •  `shuffle`: If true, the shuffle filter is activated which can improve the
+    compression ratio.
+
+    •  `checksum`: The checksum method can be `:fletcher32` or `:nochecksum`
+    (checksumming is disabled, which is the default)
+
+    •  `typename` (string): The name of the NetCDF type required for vlen arrays
+    (https://web.archive.org/save/https://www.unidata.ucar.edu/software/netcdf/netcdf-4/newdocs/netcdf-c/nc_005fdef_005fvlen.html)
 """
 function Base.write(filename::AbstractString, ::Type{NCDfile}, s::AbstractRasterStack; kw...)
     ds = NCD.Dataset(filename, "c"; attrib=_attribdict(metadata(s)))

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -97,7 +97,7 @@ Keywords are passed to `NCDatasets.defVar`.
 - `chunksizes`: Vector integers setting the chunk size. The total size of a
     chunk must be less than 4 GiB.
 
-    - `deflatelevel`: Compression level: 0 (default) means no compression and 9
+- `deflatelevel`: Compression level: 0 (default) means no compression and 9
     means maximum compression. Each chunk will be compressed individually.
 
     - `shuffle`: If true, the shuffle filter is activated which can improve the

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -87,25 +87,26 @@ Write an NCDstack to a single netcdf file, using NCDatasets.jl.
 Currently `Metadata` is not handled for dimensions, and `Metadata`
 from other [`AbstractRaster`](@ref) @types is ignored.
 
-# Arguments:
-- `kw...`: keyword arguments passed to [`NCDataset.defVar`].
+# Keywords
 
-    •  `fillvalue`: A value filled in the NetCDF file to indicate missing data. It
+Keywords are passed to `NCDatasets.defVar`.
+
+    - `fillvalue`: A value filled in the NetCDF file to indicate missing data. It
     will be stored in the `_FillValue` attribute.
 
-    •  `chunksizes`: Vector integers setting the chunk size. The total size of a
+    - `chunksizes`: Vector integers setting the chunk size. The total size of a
     chunk must be less than 4 GiB.
 
-    •  `deflatelevel`: Compression level: 0 (default) means no compression and 9
+    - `deflatelevel`: Compression level: 0 (default) means no compression and 9
     means maximum compression. Each chunk will be compressed individually.
 
-    •  `shuffle`: If true, the shuffle filter is activated which can improve the
+    - `shuffle`: If true, the shuffle filter is activated which can improve the
     compression ratio.
 
-    •  `checksum`: The checksum method can be `:fletcher32` or `:nochecksum`
+    - `checksum`: The checksum method can be `:fletcher32` or `:nochecksum`
     (checksumming is disabled, which is the default)
 
-    •  `typename` (string): The name of the NetCDF type required for vlen arrays
+    - `typename` (string): The name of the NetCDF type required for vlen arrays
     (https://web.archive.org/save/https://www.unidata.ucar.edu/software/netcdf/netcdf-4/newdocs/netcdf-c/nc_005fdef_005fvlen.html)
 """
 function Base.write(filename::AbstractString, ::Type{NCDfile}, s::AbstractRasterStack; kw...)

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -94,7 +94,7 @@ Keywords are passed to `NCDatasets.defVar`.
 - `fillvalue`: A value filled in the NetCDF file to indicate missing data. It
     will be stored in the `_FillValue` attribute.
 
-    - `chunksizes`: Vector integers setting the chunk size. The total size of a
+- `chunksizes`: Vector integers setting the chunk size. The total size of a
     chunk must be less than 4 GiB.
 
     - `deflatelevel`: Compression level: 0 (default) means no compression and 9

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -106,7 +106,7 @@ Keywords are passed to `NCDatasets.defVar`.
 - `checksum`: The checksum method can be `:fletcher32` or `:nochecksum`
     (checksumming is disabled, which is the default)
 
-    - `typename` (string): The name of the NetCDF type required for vlen arrays
+ - `typename` (string): The name of the NetCDF type required for vlen arrays
     (https://web.archive.org/save/https://www.unidata.ucar.edu/software/netcdf/netcdf-4/newdocs/netcdf-c/nc_005fdef_005fvlen.html)
 """
 function Base.write(filename::AbstractString, ::Type{NCDfile}, s::AbstractRasterStack; kw...)

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -100,7 +100,7 @@ Keywords are passed to `NCDatasets.defVar`.
 - `deflatelevel`: Compression level: 0 (default) means no compression and 9
     means maximum compression. Each chunk will be compressed individually.
 
-    - `shuffle`: If true, the shuffle filter is activated which can improve the
+- `shuffle`: If true, the shuffle filter is activated which can improve the
     compression ratio.
 
 - `checksum`: The checksum method can be `:fletcher32` or `:nochecksum`

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -103,7 +103,7 @@ Keywords are passed to `NCDatasets.defVar`.
     - `shuffle`: If true, the shuffle filter is activated which can improve the
     compression ratio.
 
-    - `checksum`: The checksum method can be `:fletcher32` or `:nochecksum`
+- `checksum`: The checksum method can be `:fletcher32` or `:nochecksum`
     (checksumming is disabled, which is the default)
 
     - `typename` (string): The name of the NetCDF type required for vlen arrays

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -225,6 +225,14 @@ stackkeys = (
             @test all(parent(saved) .=== parent(geoA))
             @test saved isa typeof(geoA)
             # TODO test crs
+
+            # test for nc `kw...`
+            geoA = read(ncarray)
+            write("tos.nc", geoA) # default `deflatelevel = 0`
+            write("tos_small.nc", geoA; deflatelevel=2)
+            @test filesize("tos_small.nc") * 1.5 < filesize("tos.nc") # compress ratio >= 1.5
+            isfile("tos.nc") && rm("tos.nc")
+            isfile("tos_small.nc") && rm("tos_small.nc")
         end
         @testset "to gdal" begin
             gdalfilename = tempname() * ".tif"


### PR DESCRIPTION
For the support of the following keyword arguments in `NCDatasets.defVar` (especially for `deflatelevel`)

    •  fillvalue: A value filled in the NetCDF file to indicate missing data. It
       will be stored in the _FillValue attribute.

    •  chunksizes: Vector integers setting the chunk size. The total size of a
       chunk must be less than 4 GiB.

    •  deflatelevel: Compression level: 0 (default) means no compression and 9
       means maximum compression. Each chunk will be compressed individually.

    •  shuffle: If true, the shuffle filter is activated which can improve the
       compression ratio.

    •  checksum: The checksum method can be :fletcher32 or :nochecksum
       (checksumming is disabled, which is the default)

    •  typename (string): The name of the NetCDF type required for vlen arrays
       (https://web.archive.org/save/https://www.unidata.ucar.edu/software/netcdf/netcdf-4/newdocs/netcdf-c/nc_005fdef_005fvlen.html)