### PR TITLE
open files before `read`, `modify`, `collect` and `Array`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -28,7 +28,7 @@ missingval(A::AbstractRaster) = A.missingval
 filename(A::AbstractRaster) = filename(parent(A))
 filename(A::AbstractArray) = nothing # Fallback
 
-cleanreturn(A::AbstractRaster) = modify(cleanreturn, A)
+cleanreturn(A::AbstractRaster) = rebuild(A, cleanreturn(parent(A)))
 cleanreturn(x) = x
 
 isdisk(A::AbstractRaster) = parent(A) isa DiskArrays.AbstractDiskArray
@@ -134,6 +134,9 @@ end
 # Base methods
 
 Base.parent(A::AbstractRaster) = A.data
+# Make sure a disk-based Raster is open before Array/collect
+Base.Array(A::AbstractRaster) = open(O -> Array(parent(O)), A)
+Base.collect(A::AbstractRaster) = open(O -> collect(parent(O)), A)
 
 """
     open(f, A::AbstractRaster; write=false)

--- a/src/array.jl
+++ b/src/array.jl
@@ -108,6 +108,14 @@ function DD.rebuild(A::AbstractRaster;
     rebuild(A, data, dims, refdims, name, metadata, missingval)
 end
 
+function DD.modify(f, A::AbstractRaster)
+    newdata = open(A) do O
+        f(parent(O))
+    end
+    size(newdata) == size(A) || error("$f returns an array with size $(size(newdata)) when the original size was $(size(A))")
+    return rebuild(A, newdata)
+end
+
 function DD.DimTable(As::Tuple{<:AbstractRaster,Vararg{<:AbstractRaster}}...)
     DimTable(DimStack(map(read, As...)))
 end

--- a/src/filearray.jl
+++ b/src/filearray.jl
@@ -85,6 +85,13 @@ end
 function MissingDiskArray(::Type{MT}, var::A) where {MT,A <: AbstractArray{T,N}} where {T,N}
     MissingDiskArray{MT,N,A}(var)
 end
+MissingDiskArray{MT,N}(var::V) where {MT,N,V} = MissingDiskArray{MT,N,V}(var)
+
+struct MissingDiskArrayConstructor{T,N} end
+(::MissingDiskArrayConstructor{T,N})(var) where {T,N} = MissingDiskArray{T,N}(var)
+
+ConstructionBase.constructorof(::Type{MissingDiskArray{T,N,V}}) where {T,N,V} =
+    MissingDiskArrayConstructor{T,N}()
 
 Base.parent(A::MissingDiskArray) = A.var
 Base.size(A::MissingDiskArray) = size(parent(A))

--- a/src/methods/replace_missing.jl
+++ b/src/methods/replace_missing.jl
@@ -31,8 +31,9 @@ function replace_missing(A::AbstractRaster{T}, missingval::MV;
     else
         nonmissingtype(T)
     end
+    old_missingval = Rasters.missingval(A)
     missingval = convert(MT, missingval)
-    repmissing(x) = isequal(x, Rasters.missingval(A)) || ismissing(x) ? missingval : x
+    repmissing(x) = isequal(x, old_missingval) || ismissing(x) ? missingval : x
     # Disk-backed arrays need to be lazy, memory-backed don't.
     # But in both cases we make sure we return an array with the missingval
     # in the eltype, even if there are no missing values in the array.

--- a/src/read.jl
+++ b/src/read.jl
@@ -6,14 +6,9 @@
 `read` will move a Rasters.jl object completely to memory.
 """
 function Base.read(x::Union{AbstractRaster,AbstractRasterStack,AbstractRasterSeries})
-    map(Base.read, x)
-end
-function Base.read(A::AbstractRaster)
-    open(A) do O 
-        modify(O) do ds
-            # Some backends don't implement `Array` properly.
-            Array{eltype(ds),ndims(ds)}(undef, size(ds)) .= ds
-        end
+    modify(x) do ds
+        # Some backends don't implement `Array` properly.
+        Array{eltype(ds),ndims(ds)}(undef, size(ds)) .= ds
     end
 end
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -6,9 +6,14 @@
 `read` will move a Rasters.jl object completely to memory.
 """
 function Base.read(x::Union{AbstractRaster,AbstractRasterStack,AbstractRasterSeries})
-    modify(x) do ds
-        # Some backends don't implement `Array` properly.
-        Array{eltype(ds),ndims(ds)}(undef, size(ds)) .= ds
+    map(Base.read, x)
+end
+function Base.read(A::AbstractRaster)
+    open(A) do O 
+        modify(O) do ds
+            # Some backends don't implement `Array` properly.
+            Array{eltype(ds),ndims(ds)}(undef, size(ds)) .= ds
+        end
     end
 end
 

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -123,9 +123,7 @@ function create(filename, ::Type{GDALfile}, T::Type, dims::DD.DimTuple;
     if hasdim(dims, Band)
         return Raster(filename; source=GDALfile)
     else
-        A = view(Raster(filename; source=GDALfile), Band(1))
-        @show typeof(Base.parent(A))
-        return A
+        return view(Raster(filename; source=GDALfile), Band(1))
     end
 end
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -71,6 +71,14 @@ end
     @test A6 == [false false; false false] 
 end
 
+
+@testset "collect and Array" begin
+    @test collect(ga1) isa Array
+    @test collect(ga1) == data1
+    @test Array(ga1) isa Array{Float64,2}
+    @test Array(ga1) == data1
+end
+
 @testset "show" begin
     sh = sprint(show, MIME("text/plain"), ga1)
     # Test but don't lock this down too much


### PR DESCRIPTION
Fixes the performance of `read`, `modify`, `collect` and `Array` by using `open` on the file first. This should have always been the implementation.

@kongdd this PR is a huge improvement to load time without needing the `lazy` flag. We might still need it, as there is always some memory overhead to using lazy DiskArrays methods. But this is a start.

Also notice that in your timings in #254 you were including compilation time in the first run. The `Raster` object is a little complicated and takes a few seconds to compile, and GDAL/ArchGDAL also compile in that first run. We can try to fix that too at some stage, but its a separate issue to this one.

For now, the second and following runs are the real load time without compilation.

This PR:
```julia
julia> using Rasters

julia> f = "/home/raf/Downloads/PMLV2_yearly_G010_v014_2017-01-01.tif"
"/home/raf/Downloads/PMLV2_yearly_G010_v014_2017-01-01.tif"

julia> @time r = read(Raster(f)) # First run: compilation + load time
  4.375702 seconds (10.60 M allocations: 1.133 GiB, 9.57% gc time, 74.30% compilation time)

julia> @time r = read(Raster(f)); # Second run - the actual load time
  0.995884 seconds (2.30 k allocations: 576.877 MiB, 0.72% gc time)
```

Master:
```julia

julia> using Rasters

julia> f = "/home/raf/Downloads/PMLV2_yearly_G010_v014_2017-01-01.tif"
"/home/raf/Downloads/PMLV2_yearly_G010_v014_2017-01-01.tif"

julia> @time r = read(Raster(f));
  8.612977 seconds (9.55 M allocations: 1.072 GiB, 2.60% gc time, 32.18% compilation time)

julia> @time r = read(Raster(f));
  5.713882 seconds (1.01 k allocations: 576.819 MiB, 2.00% gc time)
```
