### PR TITLE
read and write band names

### DIFF
--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -513,6 +513,3 @@ for T in (Any, UInt8, UInt16, Int16, UInt32, Int32, Float32, Float64)
     precompile(Raster, (DS, String, Nothing))
     precompile(Raster, (DS, String, Symbol))
 end
-
-f = "/home/raf/Downloads/PMLV2_yearly_G010_v014_2017-01-01.tif"
-RasterStack(f; layersfrom=Band)

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -4,7 +4,6 @@ const AG = ArchGDAL
 
 const GDAL_X_ORDER = ForwardOrdered()
 const GDAL_Y_ORDER = ReverseOrdered()
-const GDAL_BAND_ORDER = ForwardOrdered()
 
 const GDAL_X_LOCUS = Start()
 const GDAL_Y_LOCUS = Start()
@@ -65,7 +64,7 @@ function Base.write(
 
     correctedA = _maybe_permute_to_gdal(A) |>
         a -> noindex_to_sampled(a) |>
-        a -> reorder(a, (X(GDAL_X_ORDER), Y(GDAL_Y_ORDER), Band(GDAL_BAND_ORDER)))
+        a -> reorder(a, (X(GDAL_X_ORDER), Y(GDAL_Y_ORDER)))
 
     nbands = size(correctedA, Band())
     _gdalwrite(filename, correctedA, nbands; kw...)
@@ -141,9 +140,9 @@ function DD.dims(raster::AG.RasterDataset, crs=nothing, mappedcrs=nothing)
     nbands = AG.nraster(raster)
     bandnames = _gdal_bandnames(raster, nbands)
     band = if all(==(""), bandnames)
-        Band(Categorical(1:nbands; order=GDAL_BAND_ORDER))
+        Band(Categorical(1:nbands; order=ForwardOrdered()))
     else
-        Band(Categorical(bandnames; order=GDAL_BAND_ORDER))
+        Band(Categorical(bandnames; order=Unordered()))
     end
     
     crs = crs isa Nothing ? Rasters.crs(raster) : crs

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -51,6 +51,15 @@ gdalpath = maybedownload(url)
         @test A == A2 == A3
     end
 
+    @testset "read and write band names" begin
+        A = set(cat(gdalarray, gdalarray; dims=Band), Band=>1:2)
+        named = set(A, Band => string.(Ref("layer_"), dims(A, Band)))
+        tempfile = tempname() * ".tif"
+        write(tempfile, named)
+        @test parent(dims(Raster(tempfile), Band)) == ["layer_1", "layer_2"]
+        @test keys(RasterStack(tempfile; layersfrom=Band)) == (:layer_1, :layer_2)
+    end
+
     @testset "view" begin
         A = view(gdalarray, 1:10, 1:10, 1)
         @test A isa Raster
@@ -182,6 +191,7 @@ gdalpath = maybedownload(url)
         @testset "aggregate" begin
             ag = aggregate(mean, gdalarray, 4)
             @test ag == aggregate(mean, gdalarray, (X(4), Y(4), Band(1)))
+            ag = set(ag, Band => string.(Ref("layer_"), dims(ag, Band)))
             tempfile = tempname() * ".tif"
             write(tempfile, ag)
             open(Raster(tempfile); write=true) do dst


### PR DESCRIPTION
@kongdd This should let you read and write tif files with names for each band. For `Raster`, the `Band` dimension has names:

```julia
julia> rast = Raster(f)
3600×1500×7 Raster{Float64,3} with dimensions:
  X Projected range(-180.0, stop=179.9, length=3600) ForwardOrdered Regular Intervals crs: WellKnownText,
  Y Projected range(89.9, stop=-60.0, length=1500) ReverseOrdered Regular Intervals crs: WellKnownText,
  Band Categorical String[GPP, Ec, …, ET, days_coverage] ForwardOrdered

from file:
/home/raf/Downloads/PMLV2_yearly_G010_v014_2017-01-01.tif
```

You can select the layer by name:
```julia
julia> rast[X=20..80, Y=-30..0, Band=At("ET")]
599×299 Raster{Float64,2} with dimensions:
  X Projected range(20.0, stop=79.8, length=599) ForwardOrdered Regular Intervals crs: WellKnownText,
  Y Projected range(-0.1, stop=-29.9, length=299) ReverseOrdered Regular Intervals crs: WellKnownText
and reference dimensions:
  Band Categorical String[ET] ForwardOrdered
...
```

Notice you have to specify what dimension to use as stack layers:
```julia
st = RasterStack("/home/raf/Downloads/PMLV2_yearly_G010_v014_2017-01-01.tif"; layersfrom=Band)
st[:Ec]
```

Closes #255