### PR TITLE
make lazy=false the default for arrays and stacks

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -216,6 +216,7 @@ methods _do not_ load data from disk: they are applied later, lazily.
     this can be used to index in eg. `EPSG(4326)` lat/lon values, having it converted automatically.
     Only set this if the detected `mappedcrs` in incorrect, or the file does not have a `mappedcrs`,
     e.g. a tiff.
+- `lazy`: A `Bool` specifying if to load the stack lazily from disk. `false` by default.
 """
 struct Raster{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me,Mi} <: AbstractRaster{T,N,D,A}
     data::A
@@ -262,7 +263,7 @@ function Raster(ds, filename::AbstractString, key=nothing;
     name=Symbol(key isa Nothing ? "" : string(key)),
     metadata=metadata(ds), missingval=missingval(ds), 
     source=_sourcetype(filename), 
-    write=false, lazy=true,
+    write=false, lazy=false,
 )
     crs = defaultcrs(source, crs)
     mappedcrs = defaultmappedcrs(source, mappedcrs)

--- a/src/create.jl
+++ b/src/create.jl
@@ -6,11 +6,15 @@ function create(filename, T, A::AbstractRaster;
 )
     create(filename, T, dims(A); parent=parent(A), name, metadata, missingval, kw...)
 end
-function create(filename::AbstractString, T::Type, dims::Tuple; parent=nothing, suffix=nothing, kw...)
+function create(filename::AbstractString, T::Type, dims::Tuple;
+    lazy=true, parent=nothing, suffix=nothing, kw...
+)
     filename = _maybe_add_suffix(filename, suffix)
-    create(filename, _sourcetype(filename), T, dims; kw...)
+    create(filename, _sourcetype(filename), T, dims; lazy, kw...)
 end
-function create(filename::Nothing, T::Type, dims::Tuple; parent=nothing, suffix=nothing, missingval, kw...)
+function create(filename::Nothing, T::Type, dims::Tuple;
+    parent=nothing, suffix=nothing, missingval, kw...
+)
     T = isnothing(missingval) ? T : promote_type(T, typeof(missingval))
     data = isnothing(parent) ? Array{T}(undef, dims) : similar(parent, T, size(dims))
     Raster(data, dims; missingval, kw...)

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -70,7 +70,8 @@ end
 
 function create(filename, ::Type{GDALfile}, T::Type, dims::DD.DimTuple;
     missingval=nothing, metadata=nothing, name=nothing, keys=(name,),
-    driver=AG.extensiondriver(filename), compress="DEFLATE", chunk=nothing, parent=nothing
+    driver=AG.extensiondriver(filename), compress="DEFLATE", chunk=nothing,
+    parent=nothing, lazy=true, 
 )
     if !(keys isa Nothing || keys isa Symbol) && length(keys) > 1
         throw(ArgumentError("GDAL cant write more than one layer per file, but keys $keys have $(length(keys))"))
@@ -118,9 +119,9 @@ function create(filename, ::Type{GDALfile}, T::Type, dims::DD.DimTuple;
         end
     end
     if hasdim(dims, Band)
-        return Raster(filename; source=GDALfile)
+        return Raster(filename; source=GDALfile, lazy)
     else
-        return view(Raster(filename; source=GDALfile), Band(1))
+        return view(Raster(filename; source=GDALfile, lazy), Band(1))
     end
 end
 

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -223,7 +223,7 @@ end
 
 
 function create(filename, ::Type{GRDfile}, T::Type, dims::DD.DimTuple; 
-    name="layer", metadata=nothing, missingval=nothing, keys=(name,),
+    name="layer", metadata=nothing, missingval=nothing, keys=(name,), lazy=true, 
 )
     # Remove extension
     basename = splitext(filename)[1]
@@ -237,7 +237,7 @@ function create(filename, ::Type{GRDfile}, T::Type, dims::DD.DimTuple;
     open(basename * ".gri", write=true) do IO
         write(IO, FillArrays.Zeros(sze))
     end
-    return Raster(filename; source=GRDfile)
+    return Raster(filename; source=GRDfile, lazy)
 end
 
 # AbstractRasterStack methods

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -127,7 +127,8 @@ function Base.write(filename::AbstractString, ::Type{NCDfile}, s::AbstractRaster
 end
 
 function create(filename, ::Type{NCDfile}, T::Union{Type,Tuple}, dims::DimTuple;
-    name=:layer1, keys=(name,), layerdims=map(_->dims, keys), missingval=nothing, metadata=NoMetadata()
+    name=:layer1, keys=(name,), layerdims=map(_->dims, keys), missingval=nothing,
+    metadata=NoMetadata(), lazy=true, 
 )
     types = T isa Tuple ? T : Ref(T)
     missingval = T isa Tuple ? missingval : Ref(missingval)
@@ -137,7 +138,7 @@ function create(filename, ::Type{NCDfile}, T::Union{Type,Tuple}, dims::DimTuple;
         Raster(A, dims=lds; name=key, missingval=mv)
     end
     write(filename, NCDfile, Raster(first(layers)))
-    return Raster(filename; source=NCDfile)
+    return Raster(filename; source=NCDfile, lazy)
 end
 
 # DimensionalData methods for NCDatasets types ###############################

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -141,6 +141,7 @@ Load a file path or a `NamedTuple` of paths as a `RasterStack`, or convert argum
 - `layersfrom`: `Dimension` to source stack layers from if the file is not already multi-layered.
     `nothing` is default, so that a single `RasterStack(raster)` is a single layered stack.
     `RasterStack(raster; layersfrom=Band)` will use the bands as layers.
+- `lazy`: A `Bool` specifying if to load the stack lazily from disk. `false` by default.
 
 ```julia
 files = (:temp="temp.tif", :pressure="pressure.tif", :relhum="relhum.tif")
@@ -165,7 +166,7 @@ function RasterStack(
     RasterStack(NamedTuple{Tuple(keys)}(Tuple(filenames)); kw...)
 end
 function RasterStack(filenames::NamedTuple{K,<:Tuple{<:AbstractString,Vararg}};
-    crs=nothing, mappedcrs=nothing, source=nothing, lazy=true, kw...
+    crs=nothing, mappedcrs=nothing, source=nothing, lazy=false, kw...
 ) where K
     layers = map(keys(filenames), values(filenames)) do key, fn
         source = source isa Nothing ? _sourcetype(fn) : source

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,5 +1,6 @@
 using Rasters, Test, ArchGDAL, Dates, Statistics, GeoInterface, DataFrames
 using Rasters.LookupArrays, Rasters.Dimensions 
+using Rasters: bounds
 
 include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
 
@@ -10,7 +11,6 @@ ga99 = replace_missing(ga, -9999)
 gaNaN = replace_missing(ga, NaN32)
 gaMi = replace_missing(ga)
 st = RasterStack((a=A, b=B), (X, Y); missingval=(a=missing,b=missing))
-
 
 pointvec = [(-20.0, 30.0),
               (-20.0, 10.0),

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -43,7 +43,6 @@ end
     end)
     dNaN = replace_missing(ga, NaN32; filename="test.tif")
     @test all(isequal.(dNaN, [NaN32 7.0f0; 2.0f0 NaN32]))
-    @test Rasters.isdisk(dNaN)
     rm("test.tif")
     stNaN = replace_missing(st, NaN32; filename="teststack.tif")
     @test all(map(stNaN[Band(1)], (a=[NaN32 7.0f0; 2.0f0 NaN32], b=[1.0 0.4; 2.0 NaN])) do x, y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,8 @@ using Rasters, Test, Aqua, SafeTestsets
 
 if VERSION >= v"1.5.0"
     # Aqua.test_ambiguities([Rasters, Base, Core])
-    # Aqua.test_unbound_args(Rasters)
-    # Aqua.test_stale_deps(Rasters)
+    Aqua.test_unbound_args(Rasters)
+    Aqua.test_stale_deps(Rasters)
     Aqua.test_undefined_exports(Rasters)
     Aqua.test_project_extras(Rasters)
     Aqua.test_deps_compat(Rasters)

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -21,8 +21,8 @@ grdpath = stem * ".gri"
         @time read(Raster(grdpath));
         @time lazyarray = Raster(grdpath; lazy=true);
         @time eagerarray = Raster(grdpath; lazy=false);
-        # Lazy is the default
-        @test parent(grdarray) isa FileArray
+        # Eager is the default
+        @test parent(grdarray) isa Array
         @test parent(lazyarray) isa FileArray
         @test parent(eagerarray) isa Array
     end

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -33,8 +33,8 @@ stackkeys = (
         @time read(Raster(ncsingle));
         @time lazyarray = Raster(ncsingle; lazy=true);
         @time eagerarray = Raster(ncsingle; lazy=false);
-        # Lazy is the default
-        @test parent(ncarray) isa FileArray
+        # Eager is the default
+        @test parent(ncarray) isa Array
         @test parent(lazyarray) isa FileArray
         @test parent(eagerarray) isa Array
     end

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -29,7 +29,7 @@ stackkeys = (
 @testset "Raster" begin
     @time ncarray = Raster(ncsingle)
 
-   @testset "lazyness" begin
+    @testset "lazyness" begin
         @time read(Raster(ncsingle));
         @time lazyarray = Raster(ncsingle; lazy=true);
         @time eagerarray = Raster(ncsingle; lazy=false);
@@ -128,7 +128,7 @@ stackkeys = (
             tempfile = tempname() * ".nc"
             cp(ncsingle, tempfile)
             @test !all(Raster(tempfile)[X(1:100), Y([1, 5, 95])] .=== missing)
-            open(Raster(tempfile); write=true) do A
+            open(Raster(tempfile; lazy=true); write=true) do A
                 mask!(A; with=msk, missingval=missing)
                 # TODO: replace the CFVariable with a FileArray{NCDfile} so this is not required
                 nothing

--- a/test/sources/smap.jl
+++ b/test/sources/smap.jl
@@ -41,8 +41,8 @@ if isfile(path1) && isfile(path2)
             @time read(Raster(path1));
             @time lazyarray = Raster(path1; lazy=true);
             @time eagerarray = Raster(path1; lazy=false);
-            # Lazy is the default
-            @test parent(smaparray) isa FileArray
+            # Eager is the default
+            @test parent(smaparray) isa Array
             @test parent(lazyarray) isa FileArray
             @test parent(eagerarray) isa Array
         end


### PR DESCRIPTION
Lazy loading is still annoying sometimes when DiskArrays fails to iterate lazily for whatever reason, or just loading things up front is faster. This pr makes lazyness no longer the deffault. `lazy=true` can be passed to `Raster` or `RasterStack` to get the old behaviour.