### PR TITLE
allow south up files in gdal

### DIFF
--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -311,6 +311,10 @@ function _ncdlookup(D::Type, index, order::Order, span, sampling, metadata, crs,
     Sampled(index, order, span, sampling, metadata)
 end
 
+function _ncdorder(index)
+    index[end] > index[1] ? ForwardOrdered() : ReverseOrdered()
+end
+
 function _ncdspan(index, order)
     # Handle a length 1 index
     length(index) == 1 && return Regular(zero(eltype(index)))

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -311,11 +311,6 @@ function _ncdlookup(D::Type, index, order::Order, span, sampling, metadata, crs,
     Sampled(index, order, span, sampling, metadata)
 end
 
-
-function _ncdorder(index)
-    index[end] > index[1] ? ForwardOrdered() : ReverseOrdered()
-end
-
 function _ncdspan(index, order)
     # Handle a length 1 index
     length(index) == 1 && return Regular(zero(eltype(index)))

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -382,6 +382,20 @@ gdalpath = maybedownload(url)
         @test lookup(rotated, X).affinemap.translation == lookup(newrotated, X).affinemap.translation
     end
 
+    @testset "South up/ForwardOrdered Y rasters still work" begin
+        # This is not common in the wild, but should work anyway
+        ArchGDAL.create(
+            "test.tif", driver = ArchGDAL.getdriver("GTiff"), width=240, height=180, nbands=1, dtype=Float32
+        ) do dataset
+            ArchGDAL.write!(dataset, rand(240, 180), 1)
+        end
+        rast = Raster("test.tif")
+        @test order(dims(rast)) == (ForwardOrdered(), ForwardOrdered(), ForwardOrdered())
+        @test span(rast) == (Regular(1.0), Regular(1.0), NoSpan())
+        @test sampling(rast) == (Intervals(Start()), Intervals(Start()), NoSampling())
+        @test index(rast) == (LinRange(0.0, 239.0, 240), LinRange(0.0, 179.0, 180), 1:1)
+    end
+
 end
 
 @testset "stack" begin


### PR DESCRIPTION
This is a rare case but should still work, I guess. The tiny downside is it intoduces more type instability into general gdal file loads because order must be determined.

Closes #284

@jguerber this will solve your problem, but probably you should make north-up geotiffs anyway