### PR TITLE
bugfix raster from AbstractDimArray

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -231,7 +231,7 @@ function Raster(A::AbstractArray, dims::Tuple;
     crs=nothing, mappedcrs=nothing
 )
     A = Raster(A, Dimensions.format(dims, A), refdims, name, metadata, missingval)
-    A = isnothing(crs) ? A : setmappedcrs(A, crs)
+    A = isnothing(crs) ? A : setcrs(A, crs)
     A = isnothing(mappedcrs) ? A : setmappedcrs(A, mappedcrs)
     return A
 end

--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -282,7 +282,7 @@ end
 setmappedcrs(l::AbstractProjected, mappedcrs; dim) = rebuild(l; mappedcrs, dim=basetypeof(dim)())
 setmappedcrs(A::AbstractArray, mappedcrs; dim=nothing) = A
 function setmappedcrs(l::Sampled, mappedcrs; dim)
-    dim isa Union{XDim,YDim} ? Mpped(l; mappedcrs, dim) : l
+    dim isa Union{XDim,YDim} ? Mapped(l; mappedcrs, dim) : l
 end
 
 

--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -127,7 +127,7 @@ function Mapped(data=AutoIndex();
     Mapped(data, order, span, sampling, metadata, crs, mappedcrs, dim)
 end
 function Mapped(l::Sampled;
-    order=order(l), span=span(l), sampling=span(l),
+    order=order(l), span=span(l), sampling=sampling(l),
     metadata=metadata(l), crs=nothing, mappedcrs, dim=AutoDim()
 )
     Mapped(parent(l), order, span, sampling, metadata, crs, mappedcrs, dim)
@@ -282,7 +282,7 @@ end
 setmappedcrs(l::AbstractProjected, mappedcrs; dim) = rebuild(l; mappedcrs, dim=basetypeof(dim)())
 setmappedcrs(A::AbstractArray, mappedcrs; dim=nothing) = A
 function setmappedcrs(l::Sampled, mappedcrs; dim)
-    dim isa Union{XDim,YDim} ? Mapped(l; mappedcrs, dim) : l
+    dim isa Union{XDim,YDim} ? Mpped(l; mappedcrs, dim) : l
 end
 
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -126,3 +126,14 @@ end
     @test vra == ga1
     @test name(vra) == :from_vector
 end
+
+@testset "with properties" begin
+    rast = Raster(rand(X(10:0.1:20), Y(9:0.1:19)); 
+        name=:test, missingval=9999.9, crs=EPSG(4326), mappedcrs=EPSG(3857), refdims=(Ti(DateTime(2000,1,1)),)
+    )
+    @test name(rast) == :test
+    @test missingval(rast) == 9999.9
+    @test crs(rast) == EPSG(4326)
+    @test mappedcrs(rast) == EPSG(3857)
+    @test refdims(rast) == (Ti(DateTime(2000,1,1)),)
+end


### PR DESCRIPTION
This fixes a few bugs modifying fields of any `AbstractDimArray` in the `Raster` constructor. 

So this should work, where unfortunately its currently broken:
```julia
Raster(ones(X(10), Y(20); crs=EPSG(4226))
```

@jguerber you may run into this too if you need to set crs to write a raster. But it should be fixed soon. I did find a few bugs in raster generation from your issue!