### PR TITLE
Small fix: Ensure that dates is always defined

### DIFF
--- a/src/sources/rasterdatasources.jl
+++ b/src/sources/rasterdatasources.jl
@@ -83,10 +83,11 @@ function RasterSeries(T::Type{<:RasterDataSource}, layers;
         nothing
     end
     datedim = if haskey(values(kw), :date)
-        dates = if values(kw)[:date] isa Tuple
+        if values(kw)[:date] isa Tuple
             dates = RasterDataSources.date_sequence(T, values(kw)[:date])
             Ti(dates; lookup=Sampled(; sampling=Intervals(Start())))
         elseif values(kw)[:date] isa AbstractArray
+            dates = values(kw)[:date]
             Ti(dates; lookup=Sampled(; sampling=Intervals(Start())))
         else
             nothing
@@ -95,7 +96,7 @@ function RasterSeries(T::Type{<:RasterDataSource}, layers;
         nothing
     end
     if isnothing(monthdim) && isnothing(datedim)
-        throw(ArgumentError("A RasterSeries can only be constructed from a data source with `date` or `month` keywords that are AbstractArray. For other sources, use RasterStack or Raster directly"))
+        throw(ArgumentError("A RasterSeries can only be constructed from a data source with `date` or `month` keywords that are AbstractArray or Tuple. For other sources, use RasterStack or Raster directly"))
     end
 
     filenames = getraster(T, layers; kw...)

--- a/test/sources/rasterdatasources.jl
+++ b/test/sources/rasterdatasources.jl
@@ -92,11 +92,15 @@ if Sys.islinux()
         @test crs(st) == EPSG(4326)
         dates = DateTime(2019, 09, 19), DateTime(2019, 11, 19)
         s = RasterSeries(AWAP, layers; date=dates, resize=crop)
+        # test date as an Array
+        s2 = RasterSeries(AWAP, layers; date=[dates...], resize=crop)
         # s = RasterSeries(AWAP; date=dates, resize=resample, crs=EPSG(4326)) TODO: all the same
         # s = RasterSeries(AWAP; date=dates, resize=extend) TODO: this is slow !!!
         @test crs(s[1][:rainfall]) == EPSG(4326)
         @test A isa Raster
         @test st isa RasterStack
         @test s isa RasterSeries
+        @test s2 isa RasterSeries
+        @test length(s2) == 2 # date is an array: don't take intermediate steps
     end
 end


### PR DESCRIPTION
Hey,
I got some errors while using `date` as an `AbstractArray`, this small reorganization should fix it.