### PR TITLE
flexibilize _gdalwrite

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Rasters, Test, Aqua, SafeTestsets
+using Rasters, Test, Aqua, SafeTestsets, DiskArrays
 
 if VERSION >= v"1.5.0"
     # Aqua.test_ambiguities([Rasters, Base, Core])

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -226,7 +226,7 @@ gdalpath = maybedownload(url)
             @test all(B .=== gdalarray |> collect)
         end
 
-    end
+    end # methods
 
     @testset "conversion to Raster" begin
         geoA = gdalarray[X(1:50), Y(1:1), Band(1)]
@@ -283,6 +283,20 @@ gdalpath = maybedownload(url)
             saved3 = read(Raster(filename3))
             @test all(saved3 .== geoA3)
             @test val(dims(saved3, Band)) == 1:3
+        end
+
+        @testset "custom gdal options" begin
+            gdalarray = Raster(gdalpath; name=:test);
+            filename = tempname() * ".tif"
+            write(filename, gdalarray; driver="GTiff", options=Dict("COMPRESS"=>"DEFLATE", "PREDICTOR"=>"2"))
+            @test isfile(filename)
+            if isfile(filename)
+                ret = read(`gdalinfo $filename`, String)
+                @test contains(ret, "DEFLATE")
+                @test contains(ret, "PREDICTOR=2")
+                rm(filename)
+            end
+            @test_throws ArgumentError write(filename, gdalarray; driver="GTiff", options=Dict("COMPRESS"=>"FOOBAR"))
         end
 
         @testset "resave current" begin


### PR DESCRIPTION
Hi!
This is "slightly" breaking. In this PR I made writing gdal files a bit more flexible. Now it's possible to hand over arbitrary creation options and to use drivers for which the extension is not known (like cog).

Uhm, just noticed something is not working as inteded, but you can already have a look :)