### PR TITLE
read/write axis and standard_name for netcdf

### DIFF
--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -270,13 +270,21 @@ end
 # Find the matching dimension constructor. If its an unknown name
 # use the generic Dim with the dim name as type parameter
 function _ncddimtype(attrib, dimname)
-    haskey(attrib, "axis") && return NCD_AXIS_MAP[attrib["axis"]] 
-    @show attrib
-    if haskey(attrib, "standard_name")
-        T = get(NCD_STANDARD_NAME_MAP, attrib["standard_name"], nothing) 
-        isnothing(T) || return T
+    if haskey(attrib, "axis") 
+        k = attrib["axis"] 
+        if haskey(attrib, k) 
+            return NCD_AXIS_MAP[k] 
+        end
     end
-    haskey(NCD_DIM_MAP, dimname) && return NCD_DIM_MAP[dimname] 
+    if haskey(attrib, "standard_name")
+        k = attrib["standard_name"]
+        if haskey(NCD_STANDARD_NAME_MAP, k) 
+            return NCD_STANDARD_NAME_MAP[k]
+        end
+    end
+    if haskey(NCD_DIM_MAP, dimname) 
+        return NCD_DIM_MAP[dimname] 
+    end
     return DD.basetypeof(DD.key2dim(Symbol(dimname)))
 end
 
@@ -468,11 +476,11 @@ end
 # Add axis and standard name attributes to dimension variabls
 # We need to get better at guaranteeing if X/Y is actually measured in `longitude/latitude`
 # CF standards requires that we specify "units" if we use these standard names
-_ncd_set_axis_attrib!(at, dim::X) = at["axis"] = "X" # at["standard_name"] = "longitude";
-_ncd_set_axis_attrib!(at, dim::Y) = at["axis"] = "Y" # at["standard_name"] = "latitude"; 
-_ncd_set_axis_attrib!(at, dim::Z) = (at["axis"] = "Z"; at["standard_name"] = "depth")
-_ncd_set_axis_attrib!(at, dim::Ti) = (at["axis"] = "Ti"; at["standard_name"] = "time")
-_ncd_set_axis_attrib!(at, dim) = nothing
+_ncd_set_axis_attrib!(atr, dim::X) = atr["axis"] = "X" # at["standard_name"] = "longitude";
+_ncd_set_axis_attrib!(atr, dim::Y) = atr["axis"] = "Y" # at["standard_name"] = "latitude"; 
+_ncd_set_axis_attrib!(atr, dim::Z) = (atr["axis"] = "Z"; atr["standard_name"] = "depth")
+_ncd_set_axis_attrib!(atr, dim::Ti) = (atr["axis"] = "T"; atr["standard_name"] = "time")
+_ncd_set_axis_attrib!(atr, dim) = nothing
 
 _ncdshiftlocus(dim::Dimension) = _ncdshiftlocus(lookup(dim), dim)
 _ncdshiftlocus(::LookupArray, dim::Dimension) = dim

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -8,6 +8,14 @@ ncexamples = "https://www.unidata.ucar.edu/software/netcdf/examples/"
 ncsingle = maybedownload(joinpath(ncexamples, "tos_O1_2001-2002.nc"))
 ncmulti = maybedownload(joinpath(ncexamples, "test_echam_spectral.nc"))
 
+using NCDatasets
+f = "/home/raf/Downloads/test.nc"
+NCDatasets.Dataset(f)
+NCDatasets.Dataset(ncsingle)
+r = Raster(f)
+write("test2.nc", r)
+NCDatasets.Dataset("test2.nc")
+
 stackkeys = (
     :abso4, :aclcac, :aclcov, :ahfcon, :ahfice, :ahfl, :ahfliac, :ahfllac,
     :ahflwac, :ahfres, :ahfs, :ahfsiac, :ahfslac, :ahfswac, :albedo, :albedo_nir,
@@ -211,6 +219,11 @@ stackkeys = (
             @test size(geoA) == size(ncarray)
             filename = tempname() * ".nc"
             write(filename, geoA)
+            @testset "CF" attributes
+                @test NCDatasets.Dataset(filename)[:x].attrib["axis"] == "X"
+                @test NCDatasets.Dataset(filename)[:x].attrib["bounds"] == "x_bnds"
+                # TODO  better units and standard name handling
+            end
             saved = read(Raster(filename))
             @test size(saved) == size(geoA)
             @test refdims(saved) == refdims(geoA)

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -83,8 +83,6 @@ stackkeys = (
         @test typeof(lookup(ncarray)) <: Tuple{<:Mapped,<:Mapped,<:Sampled}
         @test bounds(ncarray) == ((0.0, 360.0), (-80.0, 90.0), (DateTime360Day(2001, 1, 1), DateTime360Day(2003, 1, 1)))
     end
-    tempfile = tempname() * ".nc"
-
 
     @testset "other fields" begin
         @test ismissing(missingval(ncarray))
@@ -211,7 +209,7 @@ stackkeys = (
             @test size(geoA) == size(ncarray)
             filename = tempname() * ".nc"
             write(filename, geoA)
-            @testset "CF" attributes
+            @testset "CF attributes" begin
                 @test NCDatasets.Dataset(filename)[:x].attrib["axis"] == "X"
                 @test NCDatasets.Dataset(filename)[:x].attrib["bounds"] == "x_bnds"
                 # TODO  better units and standard name handling

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -8,14 +8,6 @@ ncexamples = "https://www.unidata.ucar.edu/software/netcdf/examples/"
 ncsingle = maybedownload(joinpath(ncexamples, "tos_O1_2001-2002.nc"))
 ncmulti = maybedownload(joinpath(ncexamples, "test_echam_spectral.nc"))
 
-using NCDatasets
-f = "/home/raf/Downloads/test.nc"
-NCDatasets.Dataset(f)
-NCDatasets.Dataset(ncsingle)
-r = Raster(f)
-write("test2.nc", r)
-NCDatasets.Dataset("test2.nc")
-
 stackkeys = (
     :abso4, :aclcac, :aclcov, :ahfcon, :ahfice, :ahfl, :ahfliac, :ahfllac,
     :ahflwac, :ahfres, :ahfs, :ahfsiac, :ahfslac, :ahfswac, :albedo, :albedo_nir,


### PR DESCRIPTION
X, Y, Z, T axes may be indicated in a dataset, with `axis` keywords for the variable. depth, time, longitude latidute values of `standard_name` do a similar thing:

>Because identification of a coordinate type by its units is complicated by requiring the use of an external software package [UDUNITS] , we provide two optional methods that yield a direct identification. The attribute axis may be attached to a coordinate variable and given one of the values X, Y, Z or T which stand for a longitude, latitude, vertical, or time axis respectively. Alternatively the standard_name attribute may be used for direct identification. But note that these optional attributes are in addition to the required COARDS metadata.

This PR adds detecting both of these to the method for dimension detection, and writing `axis` with dimension metadata.
Writing `standard_name` can happen in some cases, but `longitude` for X requires we know the values are actually longitude. Which we often don't. 

@ryofurue if you want to review this that would be a big help.