### PR TITLE
add res keyword to rasterize and document

### DIFF
--- a/src/methods/mask.jl
+++ b/src/methods/mask.jl
@@ -1,3 +1,16 @@
+
+const GEOM_KEYWORDS = """
+- `to`: a `Raster`, `RasterStack`, `Tuple` of `Dimension` or `Extents.Extent`.
+    If no `to` object is provided the extent will be calculated from the geometries,
+    Additionally, when no `to` object or an `Extent` is passed for `to`, the `size`
+    or `res` keyword must also be used.
+- `size`: the size of the output array, as a `Tuple{Int,Int}` or single `Int` for a square.
+    Only required when `to is not used or is an `Extents.Extent`, otherwise `size`.
+- `res`: the resolution of the dimensions, a `Real` or `Tuple{<:Real,<:Real}`.
+- `shape`: Force `data` to be treated as `:polygon`, `:line` or `:point` geometries.
+    using points or lines as polygons may have unexpected results.
+"""
+
 """
     mask(A:AbstractRaster; with, missingval=missingval(A))
     mask(x; with)
@@ -19,6 +32,8 @@ or by the shape of `with`, if `with` is a geometric object.
     A tuple of `suffix` will be applied to stack layers. `keys(st)` are the default.
 
 # Geometry keywords
+
+$GEOM_KEYWORDS
 
 These can be used when `with` is a GeoInterface.jl compatible object:
 
@@ -75,7 +90,7 @@ function _mask(x::RasterStackOrArray, with; kw...)
     return _mask(x, B)
 end
 # Array mask
-function _mask(A::AbstractRaster, with::AbstractRaster; 
+function _mask(A::AbstractRaster, with::AbstractRaster;
     filename=nothing, suffix=nothing, missingval=_missingval_or_missing(A), kw...
 )
     A1 = create(filename, A; suffix, missingval)
@@ -85,10 +100,10 @@ function _mask(A::AbstractRaster, with::AbstractRaster;
     end
     return A1
 end
-function _mask(xs::AbstractRasterStack, with::AbstractRaster; suffix=keys(xs), kw...) 
+function _mask(xs::AbstractRasterStack, with::AbstractRaster; suffix=keys(xs), kw...)
     mapargs((x, s) -> mask(x; with, suffix=s, kw...), xs, suffix)
 end
-function _mask(xs::AbstractRasterSeries, with::AbstractRaster; kw...) 
+function _mask(xs::AbstractRasterSeries, with::AbstractRaster; kw...)
     map(x -> mask(x; with, kw...), xs)
 end
 
@@ -127,12 +142,12 @@ using Rasters, Plots, Dates
 awap = read(RasterStack(AWAP, (:tmin, :tmax); date=DateTime(2001, 1, 1)))
 a = plot(awap; clims=(10, 45))
 
-# Create a mask my resampling a worldclim file 
+# Create a mask my resampling a worldclim file
 wc = Raster(WorldClim{Climate}, :prec; month=1)
 wc_mask = resample(wc; to=awap)
 
-# Mask 
-mask!(awap; with=wc_mask) 
+# Mask
+mask!(awap; with=wc_mask)
 b = plot(awap; clims=(10, 45))
 
 savefig(a, "build/mask_bang_example_before.png")
@@ -184,11 +199,11 @@ _nomissingerror() = throw(ArgumentError("Array has no `missingval`. Pass a `miss
 
 """
     boolmask(obj; [missingval])
-    boolmask(obj; to)
+    boolmask(obj; [to, res, size])
 
-Create a mask array of `Bool` values, from any `AbstractArray`. An 
+Create a mask array of `Bool` values, from any `AbstractArray`. An
 `AbstractRasterStack` or `AbstractRasterSeries` are also accepted, but a mask
-is taken of the first layer or object *not* all of them. 
+is taken of the first layer or object *not* all of them.
 
 The array returned from calling `boolmask` on a `AbstractRaster` is a
 [`Raster`](@ref) with the same size and fields as the original array.
@@ -198,16 +213,13 @@ The array returned from calling `boolmask` on a `AbstractRaster` is a
 - `obj`: a [`Raster`](@ref) or [`RasterStack`](@ref), or
     a GeoInterface.jl geometry, or a vector or table of geometries.
 
-# Array Keywords
+# `Raster` / `RasterStack` Keywords
 
-- `missingval`: The missing value of the source array, with default `missingval(raster)`.
+- `misesingval`: The missing value of the source array, with default `missingval(raster)`.
 
 # Geometry keywords
 
-- `to`: an `AbstractRaster`, `AbstractRasterStack` that defines extent and resolution
-    of the output.
-- `shape`: Force `data` to be treated as `:polygon`, `:line` or `:point` geometries.
-    using points or lines as polygons may have unexpected results.
+$GEOM_KEYWORDS
 
 And specifically for `shape=:polygon`:
 
@@ -231,27 +243,12 @@ savefig("build/boolmask_example.png")
 $EXPERIMENTAL
 """
 function boolmask end
-boolmask(x::Union{AbstractRasterSeries,AbstractRasterStack,AbstractRaster}; kw...) =
-    boolmask!(_bools(x, dims(x)), x; kw...)
-boolmask(x; to, kw...) = boolmask!(_bools(to, commondims(to, (XDim, YDim))), x; kw...)
-
-_bools(x) = _bools(x, dims(x))
-_bools(x::AbstractRasterSeries, dims) = _bools(first(x), dims)
-_bools(x::AbstractRasterStack, dims) = _bools(first(x), dims)
-_bools(x, dims) = Raster(falses(dims); missingval=false)
-function _bools(A::AbstractRaster, dims)
-    # TODO: improve this so that only e.g. CuArray uses `similar`
-    # This is a little annoying to lock down for all wrapper types,
-    # maybe ArrayInterface has tools for this.
-    da = if parent(A) isa Union{Array,DA.AbstractDiskArray}
-        falses(dims) # Use a BitArray
-    else
-        fill!(similar(A, Bool, dims), false) # Fill some other array type
-    end
-    return Raster(da; missingval=false)
+function boolmask(x; kw...)
+    A = _fillraster(x, Bool; missingval=false, kw...)
+    return boolmask!(A, x; kw...)
 end
 
-function boolmask!(dest::AbstractRaster, src::AbstractRaster; 
+function boolmask!(dest::AbstractRaster, src::AbstractRaster;
     missingval=_missingval_or_missing(src)
 )
     broadcast!(a -> !isequal(a, missingval), dest, src)
@@ -271,6 +268,10 @@ for all other `AbstractArray`s it is `missing`.
 The array returned from calling `missingmask` on a `AbstractRaster` is a
 [`Raster`](@ref) with the same size and fields as the original array.
 
+# Keywords
+
+$GEOM_KEYWORDS
+
 # Example
 
 ```jldoctest
@@ -286,9 +287,18 @@ savefig("build/missingmask_example.png")
 
 $EXPERIMENTAL
 """
-function missingmask(x::AbstractRaster; missingval=missingval(x))
-    B = Raster(zeros(Union{Bool,Missing}, dims(x)); missingval=missing)
-    B .= missing
-    boolmask!(B, x; missingval)
-    return broadcast(x -> x ? true : missing, B)
+function missingmask(x; missingval=missingval(x), kw...)
+    A = _fillraster(x, Union{Missing,Bool}; missingval=missing, kw...)
+    return _missingmask!(A, x; missingval)
+end
+
+function _missingmask!(dest::AbstractRaster, src::AbstractRaster;
+    missingval=_missingval_or_missing(src)
+)
+    broadcast!(x -> isequal(x, missingval) ? missing : true, dest, src)
+end
+function _missingmask!(dest::AbstractRaster, geom; missingval, kw...)
+    B = fill_geometry!(dest, geom; fill=true, kw...)
+    broadcast!(b -> b ? true : missing, dest, B)
+    return dest
 end

--- a/src/methods/mask.jl
+++ b/src/methods/mask.jl
@@ -1,15 +1,33 @@
 
-const GEOM_KEYWORDS = """
+const TO_KEYWORD = """
 - `to`: a `Raster`, `RasterStack`, `Tuple` of `Dimension` or `Extents.Extent`.
     If no `to` object is provided the extent will be calculated from the geometries,
     Additionally, when no `to` object or an `Extent` is passed for `to`, the `size`
     or `res` keyword must also be used.
+"""
+const SIZE_KEYWORD = """
 - `size`: the size of the output array, as a `Tuple{Int,Int}` or single `Int` for a square.
     Only required when `to is not used or is an `Extents.Extent`, otherwise `size`.
+"""
+const RES_KEYWORD = """
 - `res`: the resolution of the dimensions, a `Real` or `Tuple{<:Real,<:Real}`.
+"""
+
+const SHAPE_KEYWORDS = """
 - `shape`: Force `data` to be treated as `:polygon`, `:line` or `:point` geometries.
     using points or lines as polygons may have unexpected results.
+- `boundary`: for polygons, include pixels where the `:center` is inside the polygon,
+    where the line `:touches` the pixel, or that are completely `:inside` inside the polygon.
+    The default is `:center`.
 """
+
+const GEOM_KEYWORDS = """
+$TO_KEYWORD
+$RES_KEYWORD
+$SIZE_KEYWORD
+$SHAPE_KEYWORDS
+"""
+
 
 """
     mask(A:AbstractRaster; with, missingval=missingval(A))
@@ -33,14 +51,9 @@ or by the shape of `with`, if `with` is a geometric object.
 
 # Geometry keywords
 
-$GEOM_KEYWORDS
-
 These can be used when `with` is a GeoInterface.jl compatible object:
 
-- `shape`: Force `data` to be treated as `:polygon`, `:line` or `:point`, where possible.
-- `boundary`: for polygons, include pixels where the `:center` is inside the polygon,
-    where the line `:touches` the pixel, or that are completely `:inside` inside the polygon.
-    The default is `:center`.
+$SHAPE_KEYWORDS
 
 # Example
 
@@ -215,7 +228,7 @@ The array returned from calling `boolmask` on a `AbstractRaster` is a
 
 # `Raster` / `RasterStack` Keywords
 
-- `misesingval`: The missing value of the source array, with default `missingval(raster)`.
+- `missingval`: The missing value of the source array, with default `missingval(raster)`.
 
 # Geometry keywords
 

--- a/src/methods/rasterize.jl
+++ b/src/methods/rasterize.jl
@@ -2,7 +2,7 @@ struct _Undefined end
 struct _Defined end
 
 """
-    rasterize(data; to, fill, kw...)
+    rasterize(obj; to, fill, kw...)
 
 Rasterize the a GeoInterface.jl compatable geometry or feature,
 or a Tables.jl table with a :geometry column of GeoInterface.jl objects,
@@ -10,20 +10,13 @@ or `X`, `Y` points columns.
 
 # Arguments
 
-- `data`: a GeoInterface.jl `AbstractGeometry`, or a nested `Vector` of `AbstractGeometry`,
+- `obj`: a GeoInterface.jl `AbstractGeometry`, or a nested `Vector` of `AbstractGeometry`,
     or a Tables.jl compatible object containing points and values columns.
 
 # Keywords
 
-These are detected automatically from `A` and `data` where possible.
+These are detected automatically from `obj` where possible.
 
-- `to`: a `Raster`, `RasterStack`, `Tuple` of `Dimension` or `Extents.Extent`.
-    If no `to` object is provided the extent will be calculated from the geometries, 
-    Additionally, when no `to` object or an `Extent` is passed for `to`, the `size`
-    or `res` keyword must also be used.
-- `size`: the size of the output array, as a `Tuple{Int,Int}` or single `Int` for a square.
-    Only required when `to is not used or is an `Extents.Extent`, otherwise `size`.
-- `res`: the resolution of the dimensions, a `Real` or `Tuple{<:Real,<:Real}`.
 - `fill`: the value to fill a polygon with. A `Symbol` or tuple of `Symbol` will
     be used to retrieve properties from features or column values from table rows.
 - `atol`: an absolute tolerance for rasterizing to dimensions with `Points` sampling.
@@ -35,9 +28,7 @@ These are detected automatically from `A` and `data` where possible.
 
 These can be used when a `GeoInterface.AbstractGeometry` is passed in.
 
-- `shape`: Force `data` to be treated as `:polygon`, `:line` or `:point`.
-- `boundary`: for polygons, include pixels where the `:center` is inside the polygon,
-    where the line `:touches` the pixel, or that are completely `:inside` inside the polygon.
+$GEOM_KEYWORDS
 
 # Example
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -385,12 +385,13 @@ end
 
     @testset "from geometries, tables and features of points" begin
         A = A1
+        data = pointfc
 
         for data in (pointfc, DataFrame(pointfc), multi_point, pointvec, reverse(pointvec))
             @test sum(skipmissing(rasterize(data; to=A, fill=1))) == 4
 
             @testset "to and fill Keywords are required" begin
-                @test_throws UndefKeywordError R = rasterize(data; fill=1) 
+                @test_throws ArgumentError R = rasterize(data; fill=1) 
                 @test_throws UndefKeywordError R = rasterize(data; to=A) 
             end
             @testset "NamedTuple of value fill makes a stack" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -354,7 +354,8 @@ end
         poly = polygon
         for A in (A1, A2), poly in (polygon, multi_polygon)
             ra = rasterize(poly; to=A, missingval=0, shape=:polygon, fill=1, boundary=:center)
-            @test sum(ra) === 20 * 20
+            ra_res = rasterize(poly; res=map(step, span(A)), missingval=0, shape=:polygon, fill=1, boundary=:center)
+            @test sum(ra) == sum(ra_res) === 20 * 20
             ra = rasterize(poly; to=A, shape=:polygon, fill=1, boundary=:touches)
             @test sum(skipmissing(ra)) === 21 * 21
             rasterize!(A, poly; shape=:polygon, fill=1, boundary=:inside)
@@ -372,6 +373,13 @@ end
             st = rasterize(poly; fill=(layer1=1, layer2=2), to=st)
             @test sum(skipmissing(st[:layer1])) == 400 # The last value overwrites the first
             @test sum(skipmissing(st[:layer2])) == 800
+            # Missing size / res
+            @test_throws ArgumentError rasterize(poly; fill=1)
+            # Both size + res
+            @test_throws ArgumentError rasterize(poly; res=0.1, size=200, fill=1)
+            @test_throws ArgumentError rasterize(poly; res=(0.1, 0.2), size=200, fill=1)
+            @test_throws ArgumentError rasterize(poly; res=0.1, size=(200, 200), fill=1)
+            @test_throws ArgumentError rasterize(poly; res=(0.1, 0.2), size=(200, 200), fill=1)
         end
     end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -58,6 +58,7 @@ end
     @test boolmask(ga99) == [false true; true false]
     @test boolmask(gaNaN) == [false true; true false]
     @test dims(boolmask(ga)) == (X(NoLookup(Base.OneTo(2))), Y(NoLookup(Base.OneTo(2))))
+    @test boolmask(polygon; res=1.0) == trues(X(Projected(-20:1.0:-1.0; crs=nothing)), Y(Projected(10.0:1.0:29.0; crs=nothing)))
 end
 
 @testset "missingmask" begin
@@ -65,6 +66,7 @@ end
     @test all(missingmask(ga99) .=== [missing true; true missing])
     @test all(missingmask(gaNaN) .=== [missing true; true missing])
     @test dims(missingmask(ga)) == (X(NoLookup(Base.OneTo(2))), Y(NoLookup(Base.OneTo(2))))
+    @test missingmask(polygon; res=1.0) == fill!(Raster{Union{Missing,Bool}}(undef, X(Projected(-20:1.0:-1.0; crs=nothing)), Y(Projected(10.0:1.0:29.0; crs=nothing))), true)
 end
 
 @testset "mask" begin
@@ -85,6 +87,7 @@ end
     @test Rasters.isdisk(stmask)
     rm("mask_a.tif")
     rm("mask_b.tif")
+    poly = polygon
     @testset "to polygon" begin
         for poly in (polygon, multi_polygon) 
             a1 = Raster(ones(X(-20:5), Y(0:30)))


### PR DESCRIPTION
Adds a `res` (resolution) keyword to `rasterize` so that shapefiles can be rasterized based on their extent and `res` resolution.

`res` can be a `Real` or a `Tuple{<:Real,<:Real}`