### PR TITLE
fix detecting first valid variable in netcdf

### DIFF
--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -10,8 +10,6 @@ gdalpath = maybedownload(url)
 @testset "Raster" begin
     @test_throws ArgumentError Raster("notafile.tif")
 
-    rast = Raster("/home/raf/Downloads/s1a-iw1-slc-vv-20220918t074922-20220918t074947-045056-056232-004.tiff")
-
     @time gdalarray = Raster(gdalpath; name=:test)
     @time lazyarray = Raster(gdalpath; lazy=true);
     @time eagerarray = Raster(gdalpath; lazy=false);

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -10,6 +10,8 @@ gdalpath = maybedownload(url)
 @testset "Raster" begin
     @test_throws ArgumentError Raster("notafile.tif")
 
+    rast = Raster("/home/raf/Downloads/s1a-iw1-slc-vv-20220918t074922-20220918t074947-045056-056232-004.tiff")
+
     @time gdalarray = Raster(gdalpath; name=:test)
     @time lazyarray = Raster(gdalpath; lazy=true);
     @time eagerarray = Raster(gdalpath; lazy=false);

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -56,6 +56,14 @@ stackkeys = (
         @test all(A .=== A3)
     end
 
+    @testset "ignore empty variables" begin
+        st = RasterStack((empty=view(ncarray, 1, 1, 1), full=ncarray))
+        write("emptyval_test.nc", st)
+        rast = Raster("emptyval_test.nc")
+        @test name(rast) == :full
+        rm("emptyval_test.nc")
+    end
+
     @testset "array properties" begin
         @test size(ncarray) == (180, 170, 24)
         @test ncarray isa Raster


### PR DESCRIPTION
Forgot to PR this ages ago. It just makes sure that we only read real variables in a netcdf, and e.g. not variables that are just scalars.