### PR TITLE
plot ColorTypes.Colorant rasters as images

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -70,12 +70,17 @@ end
         :aspect_ratio --> square_pixels
     end
 
-    if get(plotattributes, :seriestype, :none) == :contourf
+
+    if eltype(A) <: ColorTypes.Colorant
+        index(x), index(y), parent(A)
+    elseif get(plotattributes, :seriestype, :none) == :contourf
+        A = replace_missing(A, missing)
         clims = extrema(skipmissing(A))
         :levels --> range(clims[1], clims[2], length=20)
         index(x), index(y), clamp.(A, clims[1], clims[2])
     else
         :seriestype --> :heatmap
+        A = replace_missing(A, missing)
         index(x), index(y), parent(A)
     end
 end
@@ -193,8 +198,7 @@ _prepare(d::Dimension) = d |> _maybe_shift |> _maybe_mapped
 # Convert arrays to a consistent missing value and Forward array order
 function _prepare(A::AbstractRaster)
     reorder(A, DD.ForwardOrdered) |>
-    a -> permutedims(a, DD.commondims(>:, (ZDim, YDim, XDim, TimeDim, Dimension), dims(A))) |>
-    a -> replace_missing(a, missing)
+    a -> permutedims(a, DD.commondims(>:, (ZDim, YDim, XDim, TimeDim, Dimension), dims(A)))# |>
 end
 
 function _subsample(A, max_res)

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -1,4 +1,4 @@
-using Rasters, Test, Dates, Plots
+using Rasters, Test, Dates, Plots, ColorTypes
 
 ga2 = Raster(ones(91) * (-25:15)', (X(0.0:4.0:360.0), Y(-25.0:1.0:15.0), ); name=:Test)
 ga3 = Raster(rand(10, 41, 91), (Z(100:100:1000), Y(-20.0:1.0:20.0), X(0.0:4.0:360.0)))
@@ -33,3 +33,7 @@ plot(RasterStack(ga2, ga3))
 
 # DD fallback
 contour(ga2)
+
+# Colors
+c = Raster(rand(RGB, Y(-20.0:1.0:20.0), X(0.0:4.0:360.0)))
+plot(c)


### PR DESCRIPTION

Note this is unrelated to #339, as that is plotting multiband rasters as images. This PR is to plot rasters that already hold `ColorTypes.Colorant` (e.g. RGB) values already.