### PR TITLE
MODIS datasets need more keyword arguments

### DIFF
--- a/src/sources/rasterdatasources.jl
+++ b/src/sources/rasterdatasources.jl
@@ -15,7 +15,7 @@ Load a `RasterDataSource` as a `Raster`. `T` and `layers` are passed to
 - `month`: an `Int` between `1` and `12`, usually for `Climate` datasets
 - `date`: a `DateTime` object, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
-- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon`, `km_ab` and `km_lr`
+- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon` (coordinates of the center of the raster, as latitude and longitude), `km_ab` and `km_lr` (set how many kilometers above/below and left/right of the center coordinates)
 
 Other `Raster` keywords are passed to the `Raster` constructor.
 
@@ -40,7 +40,7 @@ Load a `RasterDataSource` as a `RasterStack`. `T` and `layers` are passed to
 - `month`: an `Int` between `1` and `12`, usually for `Climate` datasets.
 - `date`: a `DateTime` object, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
-- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon`, `km_ab` and `km_lr`
+- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon` (coordinates of the center of the raster, as latitude and longitude), `km_ab` and `km_lr` (set how many kilometers above/below and left/right of the center coordinates)
 
 Other `RasterStack` keywords are passed to the `RasterStack` constructor.
 
@@ -67,7 +67,7 @@ Load a `RasterDataSource` as an `AbstractRasterSeries`. `T`, `args` are passed t
 - `month`: a `Vector` or range of `Int` between `1` and `12`, usually for `Climate` datasets.
 - `date`: a `Vector` of `DateTime` objects, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
-- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon`, `km_ab` and `km_lr`
+- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon` (coordinates of the center of the raster, as latitude and longitude), `km_ab` and `km_lr` (set how many kilometers above/below and left/right of the center coordinates)
 
 Other `RasterSeries` keywords are passed to the `RasterSeries` constructor.
 

--- a/src/sources/rasterdatasources.jl
+++ b/src/sources/rasterdatasources.jl
@@ -84,7 +84,7 @@ function RasterSeries(T::Type{<:RasterDataSource}, layers;
     end
     datedim = if haskey(values(kw), :date)
         if values(kw)[:date] isa Tuple
-            dates = RasterDataSources.date_sequence(T, values(kw)[:date])
+            dates = RasterDataSources.date_sequence(T, values(kw)[:date]; kw...)
             Ti(dates; lookup=Sampled(; sampling=Intervals(Start())))
         elseif values(kw)[:date] isa AbstractArray
             dates = values(kw)[:date]

--- a/src/sources/rasterdatasources.jl
+++ b/src/sources/rasterdatasources.jl
@@ -15,7 +15,11 @@ Load a `RasterDataSource` as a `Raster`. `T` and `layers` are passed to
 - `month`: an `Int` between `1` and `12`, usually for `Climate` datasets
 - `date`: a `DateTime` object, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
-- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon` (coordinates of the center of the raster, as latitude and longitude), `km_ab` and `km_lr` (set how many kilometers above/below and left/right of the center coordinates)
+
+`MODIS` datasets require a specific set of keyword arguments:
+
+- `lat` and `lon`: Coordinates in decimal degrees (`Float`s ) of the center of the raster
+- `km_ab` and `km_lr`: Kilometers above/below and left/right (`Integer`s up to 100) of the center of the raster
 
 Other `Raster` keywords are passed to the `Raster` constructor.
 
@@ -40,7 +44,11 @@ Load a `RasterDataSource` as a `RasterStack`. `T` and `layers` are passed to
 - `month`: an `Int` between `1` and `12`, usually for `Climate` datasets.
 - `date`: a `DateTime` object, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
-- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon` (coordinates of the center of the raster, as latitude and longitude), `km_ab` and `km_lr` (set how many kilometers above/below and left/right of the center coordinates)
+
+`MODIS` datasets require a specific set of keyword arguments:
+
+- `lat` and `lon`: Coordinates in decimal degrees (`Float`s ) of the center of the raster
+- `km_ab` and `km_lr`: Kilometers above/below and left/right (`Integer`s up to 100) of the center of the raster
 
 Other `RasterStack` keywords are passed to the `RasterStack` constructor.
 
@@ -67,7 +75,11 @@ Load a `RasterDataSource` as an `AbstractRasterSeries`. `T`, `args` are passed t
 - `month`: a `Vector` or range of `Int` between `1` and `12`, usually for `Climate` datasets.
 - `date`: a `Vector` of `DateTime` objects, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
-- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon` (coordinates of the center of the raster, as latitude and longitude), `km_ab` and `km_lr` (set how many kilometers above/below and left/right of the center coordinates)
+
+`MODIS` datasets require a specific set of keyword arguments:
+
+- `lat` and `lon`: Coordinates in decimal degrees (`Float`s ) of the center of the raster
+- `km_ab` and `km_lr`: Kilometers above/below and left/right (`Integer`s up to 100) of the center of the raster
 
 Other `RasterSeries` keywords are passed to the `RasterSeries` constructor.
 

--- a/src/sources/rasterdatasources.jl
+++ b/src/sources/rasterdatasources.jl
@@ -120,7 +120,7 @@ _source_crs(T::Type{ALWB}) = crs=EPSG(4326)
 function _filterkw(kw)
     rds = []; gd = []
     for p in kw
-        dest = first(p) in (:date, :month, :res) ? rds : gd
+        dest = first(p) in (:date, :month, :res, :lat, :lon, :km_ab, :km_lr) ? rds : gd
         push!(dest, p)
     end
     rds, gd

--- a/src/sources/rasterdatasources.jl
+++ b/src/sources/rasterdatasources.jl
@@ -15,6 +15,7 @@ Load a `RasterDataSource` as a `Raster`. `T` and `layers` are passed to
 - `month`: an `Int` between `1` and `12`, usually for `Climate` datasets
 - `date`: a `DateTime` object, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
+- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon`, `km_ab` and `km_lr`
 
 Other `Raster` keywords are passed to the `Raster` constructor.
 
@@ -39,6 +40,7 @@ Load a `RasterDataSource` as a `RasterStack`. `T` and `layers` are passed to
 - `month`: an `Int` between `1` and `12`, usually for `Climate` datasets.
 - `date`: a `DateTime` object, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
+- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon`, `km_ab` and `km_lr`
 
 Other `RasterStack` keywords are passed to the `RasterStack` constructor.
 
@@ -65,6 +67,7 @@ Load a `RasterDataSource` as an `AbstractRasterSeries`. `T`, `args` are passed t
 - `month`: a `Vector` or range of `Int` between `1` and `12`, usually for `Climate` datasets.
 - `date`: a `Vector` of `DateTime` objects, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
+- `MODIS` datasets require a specific set of keyword arguments: `lat`, `lon`, `km_ab` and `km_lr`
 
 Other `RasterSeries` keywords are passed to the `RasterSeries` constructor.
 


### PR DESCRIPTION
Currently, calling e.g. `Raster(MODIS{MOD13Q}, :NDVI; RDS.britanny...)` throws an `UndefKeywordError` because the kwargs specific to MODIS are filtered out by `_filterkw`

This PR allows more kwargs, allowing to call MODIS sources via `Raster` directly.