### PR TITLE
Fix typos in rasterize docstrings

### DIFF
--- a/src/methods/mask.jl
+++ b/src/methods/mask.jl
@@ -7,7 +7,7 @@ const TO_KEYWORD = """
 """
 const SIZE_KEYWORD = """
 - `size`: the size of the output array, as a `Tuple{Int,Int}` or single `Int` for a square.
-    Only required when `to is not used or is an `Extents.Extent`, otherwise `size`.
+    Only required when `to` is not used or is an `Extents.Extent`, otherwise `size`.
 """
 const RES_KEYWORD = """
 - `res`: the resolution of the dimensions, a `Real` or `Tuple{<:Real,<:Real}`.
@@ -17,7 +17,7 @@ const SHAPE_KEYWORDS = """
 - `shape`: Force `data` to be treated as `:polygon`, `:line` or `:point` geometries.
     using points or lines as polygons may have unexpected results.
 - `boundary`: for polygons, include pixels where the `:center` is inside the polygon,
-    where the line `:touches` the pixel, or that are completely `:inside` inside the polygon.
+    where the polygon `:touches` the pixel, or that are completely `:inside` the polygon.
     The default is `:center`.
 """
 

--- a/src/methods/rasterize.jl
+++ b/src/methods/rasterize.jl
@@ -4,14 +4,14 @@ struct _Defined end
 """
     rasterize(obj; to, fill, kw...)
 
-Rasterize the a GeoInterface.jl compatable geometry or feature,
+Rasterize a GeoInterface.jl compatable geometry or feature,
 or a Tables.jl table with a `:geometry` column of GeoInterface.jl objects,
 or `X`, `Y` points columns.
 
 # Arguments
 
 - `obj`: a GeoInterface.jl `AbstractGeometry`, or a nested `Vector` of `AbstractGeometry`,
-    or a Tables.jl compatible object containing points and values columns.
+    or a Tables.jl compatible object containing points and values columns or an `:geometry`.
 
 # Keywords
 
@@ -136,14 +136,14 @@ end
 """
     rasterize!(dest, data; fill, atol)
 
-Rasterize the geometries in `data` into the [`Raster`](@ref) or [`RasterStack`](@ref) `x`,
+Rasterize the geometries in `data` into the [`Raster`](@ref) or [`RasterStack`](@ref) `dest`,
 using the values specified by `fill`.
 
 # Arguments
 
 - `dest`: a `Raster` or `RasterStack` to rasterize into.
-- `data`: an GeoInterface.jl compatible object or `AbstractVector` of such objects,
-    or a Tables.jl compatible table containing GeoInterface compatible objects or
+- `data`: a GeoInterface.jl compatible object or an `AbstractVector` of such objects,
+    or a Tables.jl compatible table containing `:geometry` column of GeoInterface compatible objects or
     columns with point names `X` and `Y`.
 - `fill`: the value to fill a polygon with. A `Symbol` or tuple of `Symbol` will
     be used to retrieve properties from features or column values from table rows.
@@ -163,7 +163,7 @@ These can be used when a `GeoInterface.AbstractGeometry` is passed in.
 And specifically for `shape=:polygon`:
 
 - `boundary`: include pixels where the `:center` is inside the polygon, where
-    the line `:touches` the pixel, or that are completely `:inside` inside the polygon.
+    the polygon `:touches` the pixel, or that are completely `:inside` the polygon.
 
 ## Table keywords
 

--- a/src/methods/rasterize.jl
+++ b/src/methods/rasterize.jl
@@ -11,7 +11,7 @@ or `X`, `Y` points columns.
 # Arguments
 
 - `obj`: a GeoInterface.jl `AbstractGeometry`, or a nested `Vector` of `AbstractGeometry`,
-    or a Tables.jl compatible object containing points and values columns or an `:geometry`.
+    or a Tables.jl compatible object containing a `:geometry` column or points and values columns.
 
 # Keywords
 


### PR DESCRIPTION
Fix a few typos and clarify (at least for me) some things in the rasterize docstrings.