### PR TITLE
Breaking: write and better read of series

### DIFF
--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -14,6 +14,8 @@ const REV_EXT = Dict(
 # Get the source backend for a file extension, falling back to GDALfile
 _sourcetype(filename::AbstractString) = get(REV_EXT, splitext(filename)[2], GDALfile)
 _sourcetype(filenames::NamedTuple) = _sourcetype(first(filenames))
+_sourcetype(filename, ext::Nothing) = _sourcetype(filename)
+_sourcetype(filename, ext) = get(REV_EXT, ext, GDALfile)
 
 # Internal read method
 function _open(f, filename::AbstractString; source=_sourcetype(filename), kw...)

--- a/src/series.jl
+++ b/src/series.jl
@@ -45,13 +45,47 @@ DD.modify(f, A::AbstractRasterSeries) = map(child -> modify(f, child), values(A)
 """
     RasterSeries <: AbstractRasterSeries
 
-    RasterSeries(arrays::AbstractArray{<:AbstractRaster}, dims; kw...)
-    RasterSeries(stacks::AbstractArray{<:AbstractRasterStack}, dims; kw...)
-    RasterSeries(filepaths::AbstractArray{<:AbstractString}, dims; child, duplicate_first, kw...)
-    RasterSeries(dirpath:::AbstractString, dims; ext, child, duplicate_first, kw...)
+    RasterSeries(rasters::AbstractArray{<:AbstractRaster}, dims; [refdims])
+    RasterSeries(stacks::AbstractArray{<:AbstractRasterStack}, dims; [refdims]) 
+
+    RasterSeries(paths::AbstractArray{<:AbstractString}, dims; child, duplicate_first, kw...)
+    RasterSeries(path:::AbstractString, dims; ext, separator, child, duplicate_first, kw...)
 
 Concrete implementation of [`AbstractRasterSeries`](@ref).
+
 A `RasterSeries` is an array of `Raster`s or `RasterStack`s, along some dimension(s).
+
+Existing `Raster` `RasterStack` can be wrapped in a `RasterSeries`, or new files 
+can be loaded from an array of `String` or from a single `String`.
+
+A single `String` can refer to a whole directory, or the name of a series of files in a directory,
+sharing a common stem. The differnce between the filenames can be used as the lookup for the
+series. 
+
+For example, with some tifs at these paths : 
+
+```
+"series_dir/myseries_2001-01-01T00:00:00.tif"
+"series_dir/myseries_2002-01-01T00:00:00.tif"
+```
+
+We can load a `RasterSeries` with a `DateTime` lookup:
+
+```julia
+julia> ser = RasterSeries("series_dir/myseries.tif", Ti(DateTime))
+2-element RasterSeries{Raster,1} with dimensions: 
+  Ti Sampled{DateTime} DateTime[DateTime("2001-01-01T00:00:00"), DateTime("2002-01-01T00:00:00")] ForwardOrdered Irregular Points
+```
+
+The `DateTime` suffix is parsed from the filenames. Using `Ti(Int)` would try to parse integers intead.
+
+Just using the directory will also work, unless there are other files mixed in it:
+
+```julia
+julia> ser = RasterSeries("series_dir", Ti(DateTime))
+2-element RasterSeries{Raster,1} with dimensions: 
+  Ti Sampled{DateTime} DateTime[DateTime("2001-01-01T00:00:00"), DateTime("2002-01-01T00:00:00")] ForwardOrdered Irregular Points
+```
 
 # Arguments
 
@@ -59,17 +93,24 @@ A `RasterSeries` is an array of `Raster`s or `RasterStack`s, along some dimensio
 
 # Keywords
 
-- `refdims`: existing reference dimension/s.
+When loading a series from a Vector of `String` paths or a single `String` path:
 - `child`: constructor of child objects for use when filenames are passed in,
     can be `Raster` or `RasterStack`. Defaults to `Raster`.
-- `lazy`: load files lazily. This is `true` by default for series, as it is common to
-    load many files to openare over lazily.
 - `duplicate_first::Bool`: wether to duplicate the dimensions and metadata of the
     first file with all other files. This can save load time with a large
-    series where dimensions are essentially identical. `false` by default.
-- `ext`: filename extension such as ".tiff" or ".nc". Use if only a directory path is passed in.
-- `kw`: keywords passed to the child constructor [`Raster`](@ref) or [`RasterStack`](@ref)
-    if only file names are passed in.
+    series where dimensions are identical. `false` by default.
+- `lazy`: load files lazily, `false` by default.
+- `kw`: keywords passed to the child constructor [`Raster`](@ref) or [`RasterStack`](@ref).
+
+When loading a series from a single `String` path:
+
+- `ext`: filename extension such as ".tiff" or ".nc". 
+    Use to specify a subset of files if only a directory path is passed in.
+- `separator`: separator used to split lookup elements from the rest of a filename. '_' by default.
+
+
+Others:
+- `refdims`: existing reference dimension/s, normally not required.
 """
 struct RasterSeries{T,N,D,R,A<:AbstractArray{T,N}} <: AbstractRasterSeries{T,N,D,A}
     data::A
@@ -113,30 +154,39 @@ function RasterSeries(filenames::AbstractArray{<:Union{AbstractString,NamedTuple
     end
     return RasterSeries(data, DD.format(dims, data); refdims)
 end
-function RasterSeries(path::AbstractString, dims; ext=nothing, refdims=())
+function RasterSeries(path::AbstractString, dims; refdims=(), ext=nothing, separator='_', kw...)
     if isdir(path)
         dirpath = path
         filepaths = filter_ext(dirpath, ext)
+        length(filepaths) > 0 || error("No $(isnothing(ext) ? "" : ext) files found in \"$path\" dir")
+        full_filename, _ = splitext(basename(first(filepaths)))
+        common_filename = join(split(full_filename, separator)[1:end-1])
     else
         dirpath = dirname(path)
-        filename, ext = splitext(basename(path))
+        common_filename, path_ext = splitext(basename(path))
+        ext = (isnothing(ext) && path_ext != "") ? path_ext : ext
         filepaths = filter(filter_ext(dirpath, ext)) do fp
-            basename(fp)[1:length(filename)] == filename
+            basename(fp)[1:length(common_filename)] == common_filename
         end
-        basenames = map(fp -> basename(splitext(fp)[1]), filepaths)
-        if dims isa Type 
-            dimtype = dims
-            index = map(basenames) do n
-                strip(n[length(filename)+1:end], '_')
-            end
-            # Detect integers and parse them (could try to detect other types too?)
-            if all(s -> all(isnumeric, s), index)
-                index = map(s -> parse(Int, s), index)
-            end
-            dims = (dimtype(index),)
-        end
+        length(filepaths) > 0 || error("No $(isnothing(ext) ? "" : ext) files found matching \"$common_filename\" stem and \"$ext\" extension")
     end
-    RasterSeries(filepaths, DD.format(dims, filepaths); refdims)
+    basenames = map(fp -> basename(splitext(fp)[1]), filepaths)
+    # Try to get values of the wrapped type from the filenames
+    if dims isa Dimension && val(dims) isa Type
+        T = val(dims)
+        index_strings = map(basenames) do n
+            strip(n[length(common_filename)+1:end], separator)
+        end
+        index = map(index_strings) do s
+            try
+                parse(T, s) 
+            catch
+                error("Could not parse filename segment $s as $T")
+            end
+        end
+        dims = (rebuild(dims, index),)
+    end
+    RasterSeries(filepaths, DD.format(dims, filepaths); refdims, kw...)
 end
 
 @inline function DD.rebuild(

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -21,7 +21,7 @@ cleanreturn(A::AG.RasterDataset) = Array(A)
 haslayers(::Type{GDALfile}) = false
 
 """
-    Base.write(filename::AbstractString, ::Type{GDALfile}, A::AbstractRaster; kw...)
+    Base.write(filename::AbstractString, ::Type{GDALfile}, A::AbstractRaster; force=false, kw...)
 
 Write a `Raster` to file using GDAL.
 
@@ -34,8 +34,10 @@ Write a `Raster` to file using GDAL.
 Returns `filename`.
 """
 function Base.write(
-    filename::AbstractString, ::Type{GDALfile}, A::AbstractRaster{T,2}; kw...
+    filename::AbstractString, ::Type{GDALfile}, A::AbstractRaster{T,2}; 
+    force=false, verbose=true, kw...
 ) where T
+    check_can_write(filename, force)
     all(hasdim(A, (X, Y))) || error("Array must have Y and X dims")
 
     correctedA = if lookup(A, X) isa AffineProjected
@@ -49,8 +51,10 @@ function Base.write(
     _gdalwrite(filename, correctedA, nbands; kw...)
 end
 function Base.write(
-    filename::AbstractString, ::Type{GDALfile}, A::AbstractRaster{T,3}; kw...
+    filename::AbstractString, ::Type{GDALfile}, A::AbstractRaster{T,3}; 
+    force=false, verbose=true, kw...
 ) where T
+    check_can_write(filename, force)
     all(hasdim(A, (X, Y))) || error("Array must have Y and X dims")
     hasdim(A, Band()) || error("Must have a `Band` dimension to write a 3-dimensional array")
 

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -141,14 +141,17 @@ end
 # Base methods
 
 """
-    Base.write(filename::AbstractString, ::Type{GRDfile}, s::AbstractRaster)
+    Base.write(filename::AbstractString, ::Type{GRDfile}, s::AbstractRaster; force=false)
 
 Write a `Raster` to a .grd file with a .gri header file. 
 The extension of `filename` will be ignored.
 
 Returns `filename`.
 """
-function Base.write(filename::String, ::Type{GRDfile}, A::AbstractRaster)
+function Base.write(filename::String, ::Type{GRDfile}, A::AbstractRaster; 
+    force=false, verbose=true, kw...
+)
+    check_can_write(filename, force)
     A = _maybe_use_type_missingval(filename, A)
     if hasdim(A, Band)
         correctedA = permutedims(A, (X, Y, Band)) |>

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -84,7 +84,10 @@ Write an NCDarray to a NetCDF file using NCDatasets.jl
 
 Returns `filename`.
 """
-function Base.write(filename::AbstractString, ::Type{NCDfile}, A::AbstractRaster; append=false, kw...)
+function Base.write(filename::AbstractString, ::Type{NCDfile}, A::AbstractRaster; 
+    append=false, force=false, verbose=true, kw...
+)
+    check_can_write(filename, force)
     mode  = !isfile(filename) || !append ? "c" : "a";
     ds = NCD.Dataset(filename, mode; attrib=_attribdict(metadata(A)))
     try

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -87,7 +87,12 @@ Returns `filename`.
 function Base.write(filename::AbstractString, ::Type{NCDfile}, A::AbstractRaster; 
     append=false, force=false, verbose=true, kw...
 )
-    check_can_write(filename, force)
+    mode = if append
+        isfile(filename) ? "a" : "c"
+    else
+        check_can_write(filename, force)
+        "c"
+    end
     mode  = !isfile(filename) || !append ? "c" : "a";
     ds = NCD.Dataset(filename, mode; attrib=_attribdict(metadata(A)))
     try

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,8 @@
-filter_ext(path, ext::AbstractString) = filter(fn -> splitext(fn)[2] == ext, readdir(path))
+filter_ext(path, ext::AbstractString) =
+    filter(fn -> splitext(fn)[2] == ext, readdir(path; join=true))
 filter_ext(path, exts::Union{Tuple,AbstractArray}) =
-    filter(fn -> splitext(fn)[2] in exts, readdir(path))
-filter_ext(path, ext::Nothing) = readdir(path)
+    filter(fn -> splitext(fn)[2] in exts, readdir(path; join=true))
+filter_ext(path, ext::Nothing) = readdir(path; join=true)
 
 cleankeys(name) = (_cleankey(name),)
 function cleankeys(keys::Union{NamedTuple,Tuple,AbstractArray})

--- a/src/write.jl
+++ b/src/write.jl
@@ -26,7 +26,7 @@ Other keyword arguments are passed to the `write` method for the backend.
 If the source can't be saved as a stack-like object, individual array layers will be saved.
 """
 function Base.write(path::AbstractString, s::AbstractRasterStack;
-    suffix=nothing, ext=nothing, source=_sourcetype(filename), verbose=true, kw...
+    suffix=nothing, ext=nothing, source=_sourcetype(path, ext), verbose=true, kw...
 )
     if haslayers(source)
         write(path, source, s; kw...)
@@ -70,7 +70,7 @@ See other docs for `write`. All keywords are passed through to `Raster` and `Ras
 """
 function Base.write(
     path::AbstractString, A::AbstractRasterSeries;
-    ext=nothing, source=(isnothing(ext) ? _sourcetype(path) : _sourcetype(string("filepath" * ext))), kw...
+    ext=nothing, source=_sourcetype(path, ext), kw...
 )
     base, name_ext = splitext(path)
     ext = isnothing(ext) ? name_ext : ext

--- a/src/write.jl
+++ b/src/write.jl
@@ -52,5 +52,28 @@ function Base.write(filename::AbstractString, s::AbstractRasterStack; suffix=not
     end
 end
 
+"""
+    Base.write(filename::AbstractString, s::AbstractRasterSeries; kw...)
+
+Write any [`AbstractRasterSeries`](@ref) to file, guessing the backend from the file extension.
+
+The lookup values of the series will be appended to the filename (before the extension),
+separated by underscores.
+
+## Keywords
+
+See other docs for `write`. All keywords are passed through to `Raster` and `RasterStack` methods.
+"""
+function Base.write(
+    filename::AbstractString, A::AbstractRasterSeries; kw...
+)
+    S = _sourcetype(filename) 
+    base, ext = splitext(filename)
+    map(A, DimPoints(A)) do raster, p
+        slice_filename = string(base, "_", join(map(string, p), "_"), ext)
+        write(slice_filename, S, raster; kw...)
+    end
+end
+
 # Trait for source data that has stack layers
 haslayers(T) = false

--- a/src/write.jl
+++ b/src/write.jl
@@ -10,7 +10,7 @@ function Base.write(
 )
     write(filename, source, A; kw...)
 end
-Base.write(A::AbstractRaster) = write(filename(A), A)
+Base.write(A::AbstractRaster; kw...) = write(filename(A), A; kw...)
 
 """
     Base.write(filename::AbstractString, s::AbstractRasterStack; suffix, kw...)
@@ -19,45 +19,49 @@ Write any [`AbstractRasterStack`](@ref) to file, guessing the backend from the f
 
 ## Keywords
 
-- `suffix`: suffix to append to file names. By default the layer key is used. 
+- `suffix`: suffix to append to file names. By default the layer key is used.
 
 Other keyword arguments are passed to the `write` method for the backend.
 
 If the source can't be saved as a stack-like object, individual array layers will be saved.
 """
-function Base.write(filename::AbstractString, s::AbstractRasterStack; suffix=nothing, ext=nothing,
-	 	    source=_sourcetype(filename), kw...)
-    if isnothing(ext)
-        base, ext = splitext(filename)
-    else
-        base = filename
-    end
+function Base.write(path::AbstractString, s::AbstractRasterStack;
+    suffix=nothing, ext=nothing, source=_sourcetype(filename), verbose=true, kw...
+)
     if haslayers(source)
-        write(filename, source, s; kw...)
+        write(path, source, s; kw...)
     else
         # Otherwise write separate files for each layer
-        suffix1 = if suffix === nothing
+        if isnothing(ext)
+            base, ext = splitext(path)
+        else
+            base, _ = splitext(path)
+        end
+        suffix1 = if isnothing(suffix)
             divider = Sys.iswindows() ? '\\' : '/'
             # Add an underscore to the key if there is a file name already
-            spacer = last(filename) == divider ? "" : "_"
+            spacer = last(path) == divider ? "" : "_"
             map(k -> string(spacer, k), keys(s))
         else
-            suffix 
+            suffix
         end
-        @warn string("Cannot write stacks to \"", ext, "\", writing layers as individual files")
+        if verbose
+            @warn string("Cannot write stacks to \"", ext, "\", writing layers as individual files")
+        end
         map(keys(s), suffix1) do key, sfx
             fn = string(base, sfx, ext)
-            write(fn, source, s[key])
-        end
+            @show fn
+            write(fn, source, s[key]; kw...)
+        end |> NamedTuple{keys(s)}
     end
 end
 
 """
-    Base.write(filename::AbstractString, s::AbstractRasterSeries; kw...)
+    Base.write(filepath::AbstractString, s::AbstractRasterSeries; kw...)
 
 Write any [`AbstractRasterSeries`](@ref) to file, guessing the backend from the file extension.
 
-The lookup values of the series will be appended to the filename (before the extension),
+The lookup values of the series will be appended to the filepath (before the extension),
 separated by underscores.
 
 ## Keywords
@@ -65,15 +69,36 @@ separated by underscores.
 See other docs for `write`. All keywords are passed through to `Raster` and `RasterStack` methods.
 """
 function Base.write(
-    filename::AbstractString, A::AbstractRasterSeries; kw...
+    path::AbstractString, A::AbstractRasterSeries;
+    ext=nothing, source=(isnothing(ext) ? _sourcetype(path) : _sourcetype(string("filepath" * ext))), kw...
 )
-    S = _sourcetype(filename) 
-    base, ext = splitext(filename)
+    base, name_ext = splitext(path)
+    ext = isnothing(ext) ? name_ext : ext
+    verbose = true
     map(A, DimPoints(A)) do raster, p
-        slice_filename = string(base, "_", join(map(string, p), "_"), ext)
-        write(slice_filename, S, raster; kw...)
+        lookupstring = join(map(string, p), "_")
+        written_paths = if raster isa RasterStack
+            stack_dir = joinpath(dirname(base), lookupstring)
+            mkpath(stack_dir)
+            stack_filepath = joinpath(stack_dir, basename(path))
+            write(stack_filepath, raster; source, verbose, ext, kw...)
+        else
+            slice_filename = string(base, "_", lookupstring, ext)
+            write(slice_filename, raster; source, verbose, kw...)
+        end
+        verbose = false
+        written_paths
     end
 end
 
 # Trait for source data that has stack layers
 haslayers(T) = false
+
+#  This is used in source `write` methods
+function check_can_write(filename, force)
+    if !check_can_write(Bool, filename, force)
+        throw(ArgumentError("filename already exists at $filename. use the keyword `force=true` to write anyway"))
+    end
+    return true
+end
+check_can_write(::Type{Bool}, filename, force) = (force || !isfile(filename))

--- a/src/write.jl
+++ b/src/write.jl
@@ -50,7 +50,6 @@ function Base.write(path::AbstractString, s::AbstractRasterStack;
         end
         map(keys(s), suffix1) do key, sfx
             fn = string(base, sfx, ext)
-            @show fn
             write(fn, source, s[key]; kw...)
         end |> NamedTuple{keys(s)}
     end
@@ -77,13 +76,15 @@ function Base.write(
     verbose = true
     map(A, DimPoints(A)) do raster, p
         lookupstring = join(map(string, p), "_")
-        written_paths = if raster isa RasterStack
+        written_paths = if raster isa RasterStack && !haslayers(source)
             stack_dir = joinpath(dirname(base), lookupstring)
             mkpath(stack_dir)
             stack_filepath = joinpath(stack_dir, basename(path))
             write(stack_filepath, raster; source, verbose, ext, kw...)
         else
-            slice_filename = string(base, "_", lookupstring, ext)
+            dirpath = dirname(base)
+            filename = basename(base) == "" ? lookupstring : join((basename(base), lookupstring), '_')
+            slice_filename = joinpath(dirpath, string(filename, ext))
             write(slice_filename, raster; source, verbose, kw...)
         end
         verbose = false

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -72,6 +72,7 @@ gdalpath = maybedownload(url)
         write(tempfile, named)
         @test parent(dims(Raster(tempfile), Band)) == ["layer_1", "layer_2"]
         @test keys(RasterStack(tempfile; layersfrom=Band)) == (:layer_1, :layer_2)
+        rm(tempfile)
     end
 
     @testset "view of disk array" begin
@@ -214,6 +215,7 @@ gdalpath = maybedownload(url)
                 aggregate!(mean, dst, gdalarray, 4)
             end
             @test Raster(tempfile) == ag
+            rm(tempfile)
         end
 
         @testset "mosaic" begin
@@ -270,6 +272,7 @@ gdalpath = maybedownload(url)
             @test val(dims(saved1, Y)) ≈ val(dims(geoA, Y))
             @test missingval(saved1) === missingval(geoA)
             @test refdims(saved1) == refdims(geoA)
+            rm(filename)
         end
 
         @testset "3d, with subsetting" begin
@@ -297,6 +300,8 @@ gdalpath = maybedownload(url)
             saved3 = read(Raster(filename3))
             @test all(saved3 .== geoA3)
             @test val(dims(saved3, Band)) == 1:3
+            rm(filename2)
+            rm(filename3)
         end
 
         @testset "custom gdal options" begin
@@ -317,7 +322,7 @@ gdalpath = maybedownload(url)
             filename = tempname() * ".rst"
             write(filename, gdalarray)
             gdalarray2 = Raster(filename; lazy=true)
-            write(gdalarray2)
+            write(gdalarray2; force=true)
             @test read(Raster(filename)) == read(gdalarray2)
         end
 
@@ -369,9 +374,9 @@ gdalpath = maybedownload(url)
         @testset "write missing" begin
             A = read(replace_missing(gdalarray, missing))
             filename = tempname() * ".tif"
-            # write(filename, A)
-            @test_broken missingval(Raster(filename)) === typemin(UInt8)
-            # rm(filename)
+            write(filename, A)
+            @test missingval(Raster(filename)) === typemax(UInt8)
+            rm(filename)
         end
 
         @testset "write other eltypes" begin
@@ -388,7 +393,7 @@ gdalpath = maybedownload(url)
                 Float64.(gdalarray),
                 gdalarray .+ Int16(0)im,
                 gdalarray .+ Int32(0)im,
-                # gdalarray .+ Int64(0)im, ArachGDAL/gdal wont write Complex{Int64}
+                # gdalarray .+ Int64(0)im, #ArachGDAL/gdal wont write Complex{Int64}
                 gdalarray .+ 0.0f0im,
                 gdalarray .+ 0.0im,
             )
@@ -716,6 +721,29 @@ end
     # `modify` forces `rebuild` on all containers as in-Memory variants
     modified_ser = modify(Array, stackser)
     @test typeof(modified_ser) <: RasterSeries{<:RasterStack{<:NamedTuple{(:a,:b),<:Tuple{<:Array{UInt8,3},Vararg}}}}
+
+    @testset "write" begin
+        tifser = RasterSeries([gdalpath, gdalpath], Ti([DateTime(2001), DateTime(2002)]))
+        mkdir("tifseries")
+        write("tifseries/test.tif", tifser; force=true)
+        @test isfile("tifseries/test_2001-01-01T00:00:00.tif")
+        @test isfile("tifseries/test_2002-01-01T00:00:00.tif")
+        ser1 = RasterSeries("tifseries", Ti(DateTime))
+        ser2 = RasterSeries("tifseries", Ti(DateTime); lazy=true)
+        ser3 = RasterSeries("tifseries/test.tif", Ti(DateTime))
+        ser4 = RasterSeries("tifseries", Ti(DateTime); ext=".tif")
+        ser5 = RasterSeries("tifseries/test", Ti(DateTime); ext=".tif")
+        @test dims(ser1) == dims(ser2) == dims(ser3) == dims(ser3) == dims(ser5) == dims(tifser)
+        @test_throws ErrorException RasterSeries("tifseries", Ti(Int))
+        rm("tifseries"; recursive=true)
+        mkdir("tifseries2")
+        write("tifseries2/", ser; ext=".tif")
+        RasterSeries("tifseries2/", Ti(DateTime))
+        rm("tifseries2"; recursive=true)
+        stackser = RasterSeries((a=[gdalpath, gdalpath], b=[gdalpath, gdalpath]), Ti([DateTime(2001), DateTime(2002)]))
+        mkpath("stackseries")
+        write("stackseries/test.tif", stackser; force=true)
+    end
 
     @testset "read" begin
         ser1 = read(stackser)

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -327,13 +327,14 @@ gdalpath = maybedownload(url)
         end
 
         @testset "to grd" begin
-            write("testgrd.gri", gdalarray)
+            write("testgrd.gri", gdalarray; force=true)
             grdarray = Raster("testgrd.gri")
             @test crs(grdarray) == convert(ProjString, crs(gdalarray))
             @test all(map((a, b) -> all(a .≈ b), bounds(grdarray), bounds(gdalarray)))
             @test index(grdarray, Y) ≈ index(gdalarray, Y)
             @test val(dims(grdarray, X)) ≈ val(dims(gdalarray, X))
             @test grdarray == gdalarray
+            rm("testgrd.gri")
         end
 
         @testset "from Raster" begin
@@ -444,12 +445,13 @@ gdalpath = maybedownload(url)
         end
 
         @testset "write rotated" begin
-            write("rotated.tif", rotated)
+            write("rotated.tif", rotated; force=true)
             newrotated = Raster("rotated.tif")
             plot(newrotated)
             @test rotated == newrotated
             @test lookup(rotated, X).affinemap.linear == lookup(newrotated, X).affinemap.linear
             @test lookup(rotated, X).affinemap.translation == lookup(newrotated, X).affinemap.translation
+            rm("rotated.tif")
         end
 
         @testset "Non-rotated as affine has the same extent" begin
@@ -736,13 +738,14 @@ end
         @test dims(ser1) == dims(ser2) == dims(ser3) == dims(ser3) == dims(ser5) == dims(tifser)
         @test_throws ErrorException RasterSeries("tifseries", Ti(Int))
         rm("tifseries"; recursive=true)
-        mkdir("tifseries2")
-        write("tifseries2/", ser; ext=".tif")
+        mkpath("tifseries2")
+        write("tifseries2/", tifser; ext=".tif", force=true)
         RasterSeries("tifseries2/", Ti(DateTime))
         rm("tifseries2"; recursive=true)
         stackser = RasterSeries((a=[gdalpath, gdalpath], b=[gdalpath, gdalpath]), Ti([DateTime(2001), DateTime(2002)]))
         mkpath("stackseries")
         write("stackseries/test.tif", stackser; force=true)
+        rm("stackseries"; recursive=true)
     end
 
     @testset "read" begin

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -726,7 +726,7 @@ end
 
     @testset "write" begin
         tifser = RasterSeries([gdalpath, gdalpath], Ti([DateTime(2001), DateTime(2002)]))
-        mkdir("tifseries")
+        mkpath("tifseries")
         write("tifseries/test.tif", tifser; force=true)
         @test isfile("tifseries/test_2001-01-01T00:00:00.tif")
         @test isfile("tifseries/test_2002-01-01T00:00:00.tif")
@@ -740,11 +740,17 @@ end
         rm("tifseries"; recursive=true)
         mkpath("tifseries2")
         write("tifseries2/", tifser; ext=".tif", force=true)
-        RasterSeries("tifseries2/", Ti(DateTime))
+        @test isfile("tifseries2/2001-01-01T00:00:00.tif")
+        @test isfile("tifseries2/2002-01-01T00:00:00.tif")
+        ser = RasterSeries("tifseries2/", Ti(DateTime))
         rm("tifseries2"; recursive=true)
         stackser = RasterSeries((a=[gdalpath, gdalpath], b=[gdalpath, gdalpath]), Ti([DateTime(2001), DateTime(2002)]))
         mkpath("stackseries")
         write("stackseries/test.tif", stackser; force=true)
+        @test isfile("stackseries/2001-01-01T00:00:00/test_a.tif")
+        @test isfile("stackseries/2001-01-01T00:00:00/test_b.tif")
+        @test isfile("stackseries/2002-01-01T00:00:00/test_a.tif")
+        @test isfile("stackseries/2002-01-01T00:00:00/test_b.tif")
         rm("stackseries"; recursive=true)
     end
 
@@ -825,4 +831,5 @@ end
         @test crs(gdalarray[Y(1)]) == wkt
     end
 end
+
 

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -420,7 +420,7 @@ end
 
 @testset "Grd series" begin
     grdpath2 = stem * "2" * ".gri"
-    write(grdpath2, 2 .* Raster(grdpath))
+    write(grdpath2, 2 .* Raster(grdpath); force=true)
     Raster(grdpath) .* 2 == Raster(grdpath2)
     eager_grdseries = RasterSeries([grdpath, grdpath2], (Ti,); mappedcrs=EPSG(4326))
     lazy_grdseries = RasterSeries([grdpath, grdpath2], (Ti,); mappedcrs=EPSG(4326), lazy=true)

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -247,7 +247,7 @@ stackkeys = (
 
             # test for nc `kw...`
             geoA = read(ncarray)
-            write("tos.nc", geoA) # default `deflatelevel = 0`
+            write("tos.nc", geoA; force=true) # default `deflatelevel = 0`
             write("tos_small.nc", geoA; deflatelevel=2)
             @test filesize("tos_small.nc") * 1.5 < filesize("tos.nc") # compress ratio >= 1.5
             isfile("tos.nc") && rm("tos.nc")
@@ -258,12 +258,14 @@ stackkeys = (
             x = rand(n, n)
             r1 = Raster(x, (X, Y); name = "v1")
             r2 = Raster(x, (X, Y); name = "v2")
-            f = "test.nc"
-            isfile(f) && rm(f)
-            write(f, r1, append = false); size1 = filesize(f)
-            write(f, r2; append = true); size2 = filesize(f)
+            fn = "test.nc"
+            isfile(fn) && rm(fn)
+            write(fn, r1, append=false)
+            size1 = filesize(fn)
+            write(fn, r2; append=true)
+            size2 = filesize(fn)
             @test size2 > size1*1.8 # two variable 
-            isfile(f) && rm(f)
+            isfile(fn) && rm(fn)
 
             @testset "non allowed values" begin
                 # TODO return this test when the changes in NCDatasets.jl settle
@@ -287,13 +289,15 @@ stackkeys = (
         end
         @testset "to grd" begin
             nccleaned = replace_missing(ncarray[Ti(1)], -9999.0)
-            write("testgrd.gri", nccleaned)
+            write("testgrd.gri", nccleaned; force=true)
             grdarray = Raster("testgrd.gri");
             @test crs(grdarray) == convert(ProjString, EPSG(4326))
             @test bounds(grdarray) == (bounds(nccleaned)..., (1, 1))
             @test reverse(index(grdarray, Y)) ≈ index(nccleaned, Y) .- 0.5
             @test index(grdarray, X) ≈ index(nccleaned, X) .- 1.0
             @test Raster(grdarray) ≈ reverse(nccleaned; dims=Y)
+            rm("testgrd.gri")
+            rm("testgrd.grd")
         end
     end
 

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -442,6 +442,13 @@ end
     end
     geoA = Raster(ncsingle; key=:tos)
     @test all(read(ncseries[Ti(1)][:tos]) .=== read(geoA))
+
+    write("test.nc", ncseries) 
+    @test isfile("test_1.nc")
+    @test isfile("test_2.nc")
+    RasterStack("test_1.nc")
+    rm("test_1.nc")
+    rm("test_2.nc")
 end
 
 nothing


### PR DESCRIPTION
This PR improves read of series and adds `write` to write mulitiple files.

- [x] write series of stacks - in nested folders ?
- [x] test

Breaking change here is that `force=true` has to be used to overwrite files. Once we are writing many files to nested directories it feels pretty bad just overwriting them all by default, so now `force` is required.