### PR TITLE
plots.jl recipes for series, and better thinning of plot tiles

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -120,6 +120,10 @@ end
 # We only look at arrays with X, Y, Z dims here.
 # Otherwise they fall back to DimensionalData.jl recipes
 @recipe function f(st::AbstractRasterStack)
+    D = map(d -> rebuild(d, 1), otherdims(st, (X(), Y())))
+    if length(D) > 0
+        st = view(st, D...)
+    end
     nplots = length(keys(st))
     if nplots > 1
         ncols, nrows = _balance_grid(nplots)
@@ -165,11 +169,6 @@ end
                         title := string(keys(st)[i])
                         if length(dims(A, (XDim, YDim))) > 0
                             # Get a view of the first slice of the X/Y dimension
-                            ods = otherdims(A, (X, Y))
-                            if length(ods) > 0
-                                od1s = map(d -> DD.basetypeof(d)(firstindex(d)), ods)
-                                A = view(A, od1s...)
-                            end
                             RasterPlot(), _prepare(_subsample(A, max_res))
                         else
                             framestyle := :none

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -257,7 +257,7 @@ end
     titles = string.(index(A, dims(A, 1)))
     if haskey(plotattributes, :layout)
         first = true
-        for raster in A
+        for (i, raster) in enumerate(A)
             @series begin
                 :titlefontsize := 9
                 :tickfontsize := 7

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -14,10 +14,12 @@ ga4x = Raster(
 plot(ga2)
 plot(ga3[Y(At(0.0))])
 plot(ga3[X(At(180.0))])
+plot(ga3)
 # Line plot with Z on the vertical axis
 plot(ga3[X(At(0.0)), Y(At(0.0))])
 # DD fallback line plot with Z as key (not great really)
 plot(ga4x[X(At(0.0)), Y(At(0.0))])
+plot(ga4x[X(At(0.0))])
 # DD fallback heatmap with Z on Y axis
 heatmap(ga4x[X(At(0.0)), Y(At(0.0))])
 # Cant plot 4d
@@ -38,6 +40,9 @@ contour(ga2)
 c = Raster(rand(RGB, Y(-20.0:1.0:20.0), X(0.0:4.0:360.0)))
 plot(c)
 
+# Series
+plot(RasterSeries([ga2, ga2], Z))
+plot(RasterSeries([ga2 for _ in 1:100], Ti([DateTime(i) for i in 2001:2100])))
 
 xs = 0.0:4.0:360.0
 ys = -20.0:1.0:20.0
@@ -52,4 +57,3 @@ singleton_3d_raster = Raster(rand(X(0.0:4.0:360.0), Y(-20.0:1.0:20.0), Ti(1)))
 converted = Rasters.MakieCore.convert_arguments(Rasters.MakieCore.DiscreteSurface(), singleton_3d_raster) 
 @test length(converted) == 3
 @test all(collect(converted[end] .== Float32.(singleton_3d_raster.data[:, :, 1]))) # remove if we want to handle 3d rasters with a singleton dimension
-

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -9,7 +9,7 @@ ga4ti = Raster(
 ga4x = Raster(
     rand(10, 41, 91, 4), 
     (Z(100:100:1000), Y(-20.0:1.0:20.0), X(0.0:4.0:360.0), X())
-)
+);
 
 plot(ga2)
 plot(ga3[Y(At(0.0))])
@@ -31,7 +31,9 @@ plot(ga4ti[Z(1)])
 # Rasters handles filled contours
 contourf(ga2)
 # RasterStack plot
-plot(RasterStack(ga2, ga3))
+st = RasterStack(ga2, ga3)
+plot(st)
+plot(st; layout=(2, 1))
 
 # DD fallback
 contour(ga2)


### PR DESCRIPTION
This PR refactors plotting to include plotting series, making plotting a 3d `Raster` slice to `RasterSeries` and plot that.

It also adds thinning so max 16 heatmaps are plotted at once (maybe that could be less by default, and have a keyword?).

@asinghvi17 we can match the Makie recipes with this at some point too, but don't worry about it for now.