### PR TITLE
Breaking: remove depricated `subset` function

### DIFF
--- a/src/Rasters.jl
+++ b/src/Rasters.jl
@@ -62,7 +62,7 @@ export Projected, Mapped
 export Band
 export missingval, boolmask, missingmask, replace_missing, replace_missing!,
        aggregate, aggregate!, disaggregate, disaggregate!, mask, mask!, 
-       resample, warp, zonal, crop, extend, trim, slice, points, subset,
+       resample, warp, zonal, crop, extend, trim, slice, points,
        classify, classify!, mosaic, mosaic!, extract, rasterize, rasterize!,
        coverage, coverage!, setcrs, setmappedcrs
 export crs, mappedcrs, mappedindex, mappedbounds, projectedindex, projectedbounds

--- a/src/methods/zonal.jl
+++ b/src/methods/zonal.jl
@@ -101,7 +101,6 @@ function _zonal(f, x::AbstractRaster, ::GI.AbstractGeometryTrait, geom; kw...)
     cropped = crop(x; to=geom, touches=true)
     prod(size(cropped)) > 0 || return missing
     masked = mask(cropped; with=geom, kw...)
-    @show length(collect(skipmissing(masked)))
     return f(skipmissing(masked))
 end
 function _zonal(f, st::AbstractRasterStack, ::GI.AbstractGeometryTrait, geom; kw...)

--- a/src/methods/zonal.jl
+++ b/src/methods/zonal.jl
@@ -101,6 +101,7 @@ function _zonal(f, x::AbstractRaster, ::GI.AbstractGeometryTrait, geom; kw...)
     cropped = crop(x; to=geom, touches=true)
     prod(size(cropped)) > 0 || return missing
     masked = mask(cropped; with=geom, kw...)
+    @show length(collect(skipmissing(masked)))
     return f(skipmissing(masked))
 end
 function _zonal(f, st::AbstractRasterStack, ::GI.AbstractGeometryTrait, geom; kw...)

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -35,30 +35,6 @@ isdisk(A::AbstractRasterStack) = isdisk(first(A))
 setcrs(x::AbstractRasterStack, crs) = set(x, setcrs(dims(x), crs)...)
 setmappedcrs(x::AbstractRasterStack, mappedcrs) = set(x, setmappedcrs(dims(x), mappedcrs)...)
 
-"""
-    subset(s::AbstractRasterStack, keys)
-
-Subset a stack to hold only the layers in `keys`, where `keys` is a `Tuple`
-or `Array` of `String` or `Symbol`, or a `Tuple` or `Array` of `Int`
-
-*Depreciated*: As it is now possible to subset `NamedTuple` by indexing
-with a `Tuple` of `Symbol` in `getindex`, that is also possible for any
-`AbstractDimStack` like `RasterStack`. So `subset` is obsolete and will be
-remove in future versions.
-
-Use:
-
-```julia
-s[(:key1, :key2)]
-"""
-subset(s::AbstractRasterStack, keys) = subset(s, Tuple(keys))
-function subset(s::AbstractRasterStack, keys::NTuple{<:Any,<:Key})
-    RasterStack(map(k -> s[k], Tuple(keys)))
-end
-function subset(s::AbstractRasterStack, I::NTuple{<:Any,Int})
-    subset(s, map(i -> keys(s)[i], I))
-end
-
 _singlemissingval(mvs::NamedTuple, key) = mvs[key]
 _singlemissingval(mv, key) = mv
 

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -392,7 +392,7 @@ end
     end
 
     @testset "Subsetting keys" begin
-        smallstack = subset(ncstack, (:albedo, :evap, :runoff))
+        smallstack = ncstack[(:albedo, :evap, :runoff)]
         @test keys(smallstack) == (:albedo, :evap, :runoff)
     end
 


### PR DESCRIPTION
This function has been depricated for ages, as you can now just index with a tuple of symbols: `stack[(:a, :b)]`.

It also clashes with DataFrames.jl `subset`, which is a pain.