### PR TITLE
Better resample

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -64,6 +64,7 @@ function crs(obj)
         nothing
     end
 end
+crs(::Nothing) = nothing
 crs(dim::Dimension) = crs(lookup(dim))
 
 """

--- a/src/methods/mask.jl
+++ b/src/methods/mask.jl
@@ -6,10 +6,11 @@ const TO_KEYWORD = """
 """
 const SIZE_KEYWORD = """
 - `size`: the size of the output array, as a `Tuple{Int,Int}` or single `Int` for a square.
-    Only required when `to` is not used or is an `Extents.Extent`, otherwise `size`.
+    Only required when `to` is not used or is an `Extents.Extent`, and `res` is not used.
 """
 const RES_KEYWORD = """
 - `res`: the resolution of the dimensions, a `Real` or `Tuple{<:Real,<:Real}`.
+    Only required when `to` is not used or is an `Extents.Extent`, and `size` is not used.
 """
 const CRS_KEYWORD = """
 - `crs`: a `crs` which will be attached to the resulting raster when `to` not passed

--- a/src/methods/resample.jl
+++ b/src/methods/resample.jl
@@ -1,7 +1,6 @@
 """
-	resample(x, resolution::Number; crs, method)
-	resample(x; to, method)
-    resample(xs...; to=first(xs), method)
+	resample(x; to, size, res, method)
+    resample(xs...; to=first(xs), size, res, method)
 
 `resample` uses `ArchGDAL.gdalwarp` to resample a [`Raster`](@ref) or
 [`RasterStack`](@ref) to a new `resolution` and optionally new `crs`,
@@ -9,16 +8,15 @@ or to snap to the bounds, resolution and crs of the object `to`.
 
 # Arguments
 
-- `x`: the object to resample.
-- `resolution`: a `Number` specifying the resolution for the output.
-    If the keyword argument `crs` (described below) is specified, `resolution` must be in units of the `crs`.
+- `x`: the object/s to resample.
 
 # Keywords
 
-- `to`: an `AbstractRaster` whose resolution, crs and bounds will be snapped to.
-    For best results it should roughly cover the same extent, or be a subset of `A`.
-- `crs`: A `GeoFormatTypes.GeoFormat` such as `EPSG(x)` or `WellKnownText(string)` specifying an
-    output crs (`A` will be reprojected to `crs` in addition to being resampled). Defaults to `crs(A)`
+- `to`: a `Raster`, `RasterStack`, `Tuple` of `Dimension` or `Extents.Extent`.
+    If no `to` object is provided the extent will be calculated from `x`,
+$RES_KEYWORD
+- `crs`: A `GeoFormatTypes.GeoFormat` coordinate reference system for the output raster, 
+    such as `EPSG(x)` or `WellKnownText(string)`. Defaults to `crs(A)`.
 - `method`: A `Symbol` or `String` specifying the method to use for resampling.
     From the docs for [`gdalwarp`](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r):
     * `:near`: nearest neighbour resampling (default, fastest algorithm, worst interpolation quality).
@@ -38,12 +36,9 @@ or to snap to the bounds, resolution and crs of the object `to`.
 
     Where NODATA values are set to `missingval`.
 
-Notes:
-- `missingval` of `missing` does not work with GDAL. Use `replace_missing(A, newmissingval)` to
-  assign a missing value before using `resample` if the current value is `missing`. This will be
-  automated in future versions.
-- GDAL may cause some unexpected changes in the data, such as returning a reversed dimension or
-  changing the `crs` datatype from `EPSG` to `WellKnownText`.
+Note:
+- GDAL may cause some unexpected changes in the data, such as returning a reversed Y dimension or
+  changing the `crs` type from `EPSG` to `WellKnownText` (it will represent the same CRS).
 
 # Example
 
@@ -73,6 +68,7 @@ savefig(b, "build/resample_example_after.png"); nothing
 $EXPERIMENTAL
 """
 function resample end
+resample(x, res; kw...) = resample(x; res, kw...)
 resample(xs::RasterStackOrArray...; kw...) = resample(xs; kw...)
 function resample(ser::AbstractRasterSeries, args...; kw...)
     map(x -> resample(x, args...; kw...), ser)
@@ -80,42 +76,82 @@ end
 function resample(xs::Union{Tuple,NamedTuple}; to=first(xs), kw...)
     map(x -> resample(x; to, kw...), xs)
 end
-function resample(A::RasterStackOrArray, resolution::Number; kw...)
-    dimres = map(d -> DD.basetypeof(d)(resolution), dims(A, (XDim, YDim)))
-    resample(A, dimres; kw...)
-end
-function resample(A::RasterStackOrArray, pairs::Pair...; kw...)
-    resample(A, map((D, x) -> D(x), pairs); kw...)
-end
-function resample(A::RasterStackOrArray, resdims::DimTuple;
-    crs::GeoFormat=crs(A), method=:near, kw...
+function resample(x::RasterStackOrArray; 
+    # We need to combine the `size` and `res` keywords with 
+    # the extent in extent2dims, even if we already have dims.
+    to=nothing, res=nothing, crs=nothing, method=:near, kw...
 )
-    wkt = convert(String, convert(WellKnownText, crs))
-    res = map(val, dims(resdims, (YDim, XDim)))
-    flags = Dict(
-        :t_srs => wkt,
-        :tr => res,
-        :r => method,
-    )
-    return warp(A, flags; kw...)
-end
-function resample(A::RasterStackOrArray; to, method=:near, kw...)
-    all(hasdim(to, (XDim, YDim))) || throw(ArgumentError("`to` mush have both XDim and YDim dimensions to resize with GDAL"))
-    if sampling(to, XDim) isa Points
-        to = set(to, dims(to, XDim) => Intervals(Start()))
-    end
-    if sampling(to, YDim) isa Points
-        to = set(to, dims(to, YDim) => Intervals(Start()))
+    flags = Dict{Symbol,Any}()
+
+    # Method
+    flags[:r] = method
+
+    # Extent
+    if to isa Extents.Extent || isnothing(dims(to))
+        to = to isa Extents.Extent ? to : GeoInterface.extent(to)
+        if !isnothing(to)
+            # Get the extent of geometries
+            (xmin, xmax), (ymin, ymax) = to[(:X, :Y)]
+            flags[:te] = [xmin, ymin, xmax, ymax]
+        end
+    else
+        all(hasdim(to, (XDim, YDim))) || throw(ArgumentError("`to` mush have both XDim and YDim dimensions to resize with GDAL"))
+        if sampling(to, XDim) isa Points
+            to = set(to, dims(to, XDim) => Intervals(Start()))
+        end
+        if sampling(to, YDim) isa Points
+            to = set(to, dims(to, YDim) => Intervals(Start()))
+        end
+
+        # Set res from `to` if it was not already set
+        if isnothing(res)
+            xres, yres = map(abs ∘ step, span(to, (XDim, YDim)))
+            flags[:tr] = [yres, xres]
+        end
+        (xmin, xmax), (ymin, ymax) = bounds(to, (XDim, YDim))
+        flag[:te] = [xmin, ymin, xmax, ymax]
     end
 
-    wkt = convert(String, convert(WellKnownText, crs(to)))
-    xres, yres = map(abs ∘ step, span(to, (XDim, YDim)))
-    (xmin, xmax), (ymin, ymax) = bounds(to, (XDim, YDim))
-    flags = Dict(
-        :t_srs => wkt,
-        :tr => [yres, xres],
-        :te => [xmin, ymin, xmax, ymax],
-        :r => method,
-    )
-    return warp(A, flags; kw...)
+    # CRS
+    crs = if isnothing(crs) 
+        if to isa Extents.Extent
+            nothing
+        else
+            # get crs from `to` or `x` if none was passed in
+            isnothing(Rasters.crs(to)) ? Rasters.crs(x) : Rasters.crs(to)
+        end
+    else
+        crs
+    end
+    if !isnothing(crs)
+        wkt = convert(String, convert(WellKnownText, crs))
+        flags[:t_srs] = wkt
+        if isnothing(Rasters.crs(x))
+            @warn "You have set a crs to resample to, but the object does not have crs so GDAL will assume it is already in the target crs. Use `newraster = setcrs(raster, somecrs)` to fix this."
+        end
+    end
+
+    # Resolution
+    if !isnothing(res)
+        xres, yres = if res isa Real
+            res, res
+        elseif res isa DimTuple
+            map(val, dims(res, (XDim, YDim)))
+        elseif res isa Tuple
+            res
+        else
+            throw(ArgumentError("`res` must be a `Real`, a `Tuple` of `Real` or `Dimension` wrapping `Real`. Got $res"))
+        end
+        flags[:tr] = [yres, xres]
+    end
+
+    # resample with `warp`
+    resampled = warp(x, flags; kw...)
+
+    # Return crs to the original type, from GDAL it will always be WellKnownText
+    if isnothing(crs)
+        return setcrs(resampled, Rasters.crs(x))
+    else
+        return setcrs(resampled, crs)
+    end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -137,7 +137,7 @@ function _extent2dims(to::Extents.Extent, size::Nothing, res::Nothing, crs)
     isnothing(res) && throw(ArgumentError("Pass either `size` or `res` keywords or a `Tuple` of `Dimension`s for `to`."))
 end
 function _extent2dims(to::Extents.Extent, size, res, crs)
-    isnothing(res) || throw(ArgumentError("Both `size` and `res` keywords are passed, but only one can be used"))
+    isnothing(res) || _size_and_res_error()
 end
 function _extent2dims(to::Extents.Extent{K}, size::Nothing, res::Real, crs) where K
     tuple_res = ntuple(_ -> res, length(K))
@@ -198,6 +198,8 @@ _progress(args...; kw...) = ProgressMeter.Progress(args...; color=:blue, barlen=
 
 # Function barrier for splatted vector broadcast
 @noinline _do_broadcast!(f, x, args...) = broadcast!(f, x, args...)
+
+_size_and_res_error() = throw(ArgumentError("Both `size` and `res` keywords are passed, but only one can be used"))
 
 _type_missingval(::Type{T}) where T = typemin(T)
 _type_missingval(::Type{T}) where T<:Unsigned = typemax(T) 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -761,6 +761,22 @@ end
         @test size(dims(resampled, (X, Y))) == size(dims(cea, (X, Y))) .* 2
         # GDAL fp error see above
         @test_broken extent(cea) = extent(resampled)
+        resampled = resample(cea; res=(res, 2res))
+        @test size(dims(resampled, (X, Y))) == (size(cea, X) .* 2, size(cea, Y))
+        resampled = resample(cea; res=(X(2res), Y(res)))
+        @test size(dims(resampled, (X, Y))) == (size(cea, X), size(cea, Y) * 2)
+    end
+
+    @testset "only `size` kw sets the size" begin
+        res = step(span(cea, X)) / 2
+        resampled = resample(cea; size=(100, 200))
+        @test crs(cea) == crs(resampled)
+        @test size(dims(resampled, (X, Y))) == size(resampled[:, :, 1]) == (100, 200)
+        resampled = resample(cea; size=(X(99), Y(111)))
+        @test crs(cea) == crs(resampled)
+        @test size(dims(resampled, (X, Y))) == size(resampled[:, :, 1]) == (99, 111)
+        resampled = resample(cea; size=100)
+        @test size(dims(resampled, (X, Y))) == size(resampled[:, :, 1]) == (100, 100)
     end
 
     @testset "Extent `to` can resize arbitrarily" begin
@@ -782,7 +798,7 @@ end
     end
 
     @testset "only `crs` kw changes the array size" begin
-        resampled = resample(cea; crs=EPSG(3857), method=resample_method)
+        resampled = resample(cea; crs=EPSG(3857), method)
         @test size(dims(resampled, (X, Y))) !== size(dims(cea, (X, Y)))
         @test crs(resampled) == EPSG(3857)
     end
@@ -790,6 +806,6 @@ end
     @testset "no existing crs warns" begin
         nocrs = setcrs(cea, nothing)
         @test crs(nocrs) == nothing
-        @test_warn "does not have crs" resample(nocrs; crs=output_crs, method=resample_method)
+        @test_warn "does not have crs" resample(nocrs; crs=output_crs, method)
     end
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -788,10 +788,12 @@ end
         @test sum(x -> x === missingval(resampled), resampled) > length(resampled) / 2
     end
 
-    @testset "Geometries work for `to`" begin
-        GeoInterface.Polygon([[(0.0, 4e6), (-1e5, 4.4e6), (-1e5, 4.2e6)]])
-        resampled = resample(cea; to)
-        @test all(map((bs...,) -> all(map(≈, bs...)), extent(resampled), to))
+    @testset "Geometries work as `to`" begin
+        geom = GeoInterface.Polygon([[(0.0, 4e6), (-1e5, 4.4e6), (-1e5, 4.2e6)]])
+        resampled = resample(cea; to=geom)
+        @test map(extent(resampled[Band(1)]), GeoInterface.extent(geom)) do bs1, bs2 
+            map(≈, bs2, bs2) |> all 
+        end |> all
         @test crs(cea) == crs(resampled)
         # Most of the area is extended, and filled with missingval
         @test sum(x -> x === missingval(resampled), resampled) > length(resampled) / 2


### PR DESCRIPTION
Fixes #411 and fixes #399

Now `resample` has `res` and `size` keywords and accepts an Extents.Extent for `to`, similar to `rasterize`.

It will also warn if your raster has no crs.