### PR TITLE
Mention crs type in the docstrings

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -235,7 +235,7 @@ methods _do not_ load data from disk: they are applied later, lazily.
 - `metadata`: `ArrayMetadata` object for the array, or `NoMetadata()`.
 - `crs`: the coordinate reference system of  the objects `XDim`/`YDim` dimensions. 
     Only set this if you know the detected crs is incrorrect, or it is not present in
-    the file. The crs is expected to be a `GeoFormatTypes Geom or Mixed` type. 
+    the file. The `crs` is expected to be a GeoFormatTypes.jl `CRS` or `Mixed` `GeoFormat` type. 
 - `mappedcrs`: the mapped coordinate reference system of the objects `XDim`/`YDim` dimensions.
     for `Mapped` lookups these are the actual values of the index. For `Projected` lookups
     this can be used to index in eg. `EPSG(4326)` lat/lon values, having it converted automatically.

--- a/src/array.jl
+++ b/src/array.jl
@@ -240,7 +240,7 @@ methods _do not_ load data from disk: they are applied later, lazily.
     for `Mapped` lookups these are the actual values of the index. For `Projected` lookups
     this can be used to index in eg. `EPSG(4326)` lat/lon values, having it converted automatically.
     Only set this if the detected `mappedcrs` in incorrect, or the file does not have a `mappedcrs`,
-    e.g. a tiff. The mappedcrs is expected to be a `GeoFormatTypes Geom or Mixed` type.
+    e.g. a tiff. The `mappedcrs` is expected to be a GeoFormatTypes.jl `CRS` or `Mixed` `GeoFormat` type. 
 
 # Internal Keywords
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -53,6 +53,7 @@ or of the `Y`/`X` dims of an `AbstractRaster`.
 
 For [`Mapped`](@ref) lookup this may be `nothing` as there may be no projected
 coordinate reference system at all.
+See [`setcrs`](@ref) to set it manually.
 """
 function crs end
 function crs(obj)
@@ -76,6 +77,7 @@ values form the mappedcrs defined projection to the underlying projection, and t
 show plot axes in the mapped projection.
 
 In `Mapped` lookup this is the coordinate reference system of the index values.
+See [`setmappedcrs`](@ref) to set it manually.
 """
 function mappedcrs end
 function mappedcrs(obj)
@@ -233,12 +235,12 @@ methods _do not_ load data from disk: they are applied later, lazily.
 - `metadata`: `ArrayMetadata` object for the array, or `NoMetadata()`.
 - `crs`: the coordinate reference system of  the objects `XDim`/`YDim` dimensions. 
     Only set this if you know the detected crs is incrorrect, or it is not present in
-    the file.
+    the file. The crs is expected to be a `GeoFormatTypes Geom or Mixed` type. 
 - `mappedcrs`: the mapped coordinate reference system of the objects `XDim`/`YDim` dimensions.
     for `Mapped` lookups these are the actual values of the index. For `Projected` lookups
     this can be used to index in eg. `EPSG(4326)` lat/lon values, having it converted automatically.
     Only set this if the detected `mappedcrs` in incorrect, or the file does not have a `mappedcrs`,
-    e.g. a tiff.
+    e.g. a tiff. The mappedcrs is expected to be a `GeoFormatTypes Geom or Mixed` type.
 
 # Internal Keywords
 

--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -286,7 +286,7 @@ end
     setcrs(x, crs)
 
 Set the crs of a `Raster`, `RasterStack`, `Tuple` of `Dimension`, or a `Dimension`.
-The crs is expected to be a `GeoFormatTypes Geom or Mixed` type.
+The `crs` is expected to be a GeoFormatTypes.jl `CRS` or `Mixed` `GeoFormat` type
 """
 setcrs(dims::DimTuple, crs) = map(d -> setcrs(d, crs), dims)
 function setcrs(dim::Dimension, crs)

--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -286,6 +286,7 @@ end
     setcrs(x, crs)
 
 Set the crs of a `Raster`, `RasterStack`, `Tuple` of `Dimension`, or a `Dimension`.
+The crs is expected to be a `GeoFormatTypes Geom or Mixed` type.
 """
 setcrs(dims::DimTuple, crs) = map(d -> setcrs(d, crs), dims)
 function setcrs(dim::Dimension, crs)
@@ -302,6 +303,7 @@ setcrs(A::AbstractArray, crs; dim=nothing) = A
 
 Set the mapped crs of a `Raster`, a `RasterStack`, a `Tuple`
 of `Dimension`, or a `Dimension`.
+The crs is expected to be a `GeoFormatTypes Geom or Mixed` type.
 """
 setmappedcrs(dims::DimTuple, mappedcrs) = map(d -> setmappedcrs(d, mappedcrs), dims)
 function setmappedcrs(dim::Dimension, mappedcrs)

--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -303,7 +303,7 @@ setcrs(A::AbstractArray, crs; dim=nothing) = A
 
 Set the mapped crs of a `Raster`, a `RasterStack`, a `Tuple`
 of `Dimension`, or a `Dimension`.
-The crs is expected to be a `GeoFormatTypes Geom or Mixed` type.
+The `crs` is expected to be a GeoFormatTypes.jl `CRS` or `Mixed` `GeoFormat` type
 """
 setmappedcrs(dims::DimTuple, mappedcrs) = map(d -> setmappedcrs(d, mappedcrs), dims)
 function setmappedcrs(dim::Dimension, mappedcrs)


### PR DESCRIPTION
I mention the GeoFormatTypes in the docstrings of Raster, setcrs and setmappedcrs and I also added a reference to setcrs and setmappedcrs to the corresponding getter functions. 
I hope that the references work properly. 

This closes #417 .