### PR TITLE
Fix some typos in line rasterization methods

### DIFF
--- a/src/methods/rasterize.jl
+++ b/src/methods/rasterize.jl
@@ -162,12 +162,12 @@ function _rasterize(to::DimTuple, data::T; fill, name=Symbol(""), reduce=nothing
         _rasterize(to, GeoInterface.trait(data), data; reduce, fill, init, name, kw...)
     end
 end
-function _rasterize(to::DimTuple, ::GI.AbstractFeatureCollectionTrait, fc; name, reduce, fill, kw...)
+function _rasterize(to::DimTuple, ::GI.AbstractFeatureCollectionTrait, fc; name, reduce, fill, init, kw...)
     # TODO: how to handle when there are fillvals with different types
     fillval = _featurefillval(GI.getfeature(fc, 1), fill)
     init = isnothing(init) ? _reduce_init(reduce, fillval) : init
     name = _filter_name(name, fill)
-    return _create_rasterize_dest(to1; kw..., fill=fillval, init, name) do dest
+    return _create_rasterize_dest(to; kw..., fill=fillval, init, name) do dest
         rasterize!(dest, fc; reduce, fill, kw..., missingval=missingval(dest))
     end
 end
@@ -310,8 +310,8 @@ function rasterize!(x::RasterStackOrArray, data::T; fill, reduce=nothing, kw...)
     return x
 end
 function _rasterize!(x, ::GI.AbstractFeatureCollectionTrait, fc; reduce=nothing, fill, kw...)
-    fill_itr = _iterable_fill(fc, keyorfill)
-    features = GI.feaatures(fc)
+    fill_itr = _iterable_fill(fc, fill)
+    features = GI.getfeature(fc)
     return _rasterize!(x, nothing, features; fill=fill_itr, kw...)
 end
 # Single object rasterization


### PR DESCRIPTION
Had to debug this when running Rasters.  It's actually kind of slow on a FeatureCollection - will have to figure out (a) why and (b) how to optimize this.

The end goal is to create a kind of `DatashaderAxis` in Makie, which can be plotted into, and extracts geometries from all those plots, then datashades them.

It would be nice to use an "online" rasterization interface as well, would make the workflow a lot cleaner.  I can see a function `rasterize!` and will experiment with it!

Here's the code I used with this:

```julia

f, a, p = series([rand(Point2f, 40) for i in 1:50]; color = rand(RGBAf, 100))
for k in 1:20
    scatter!(a, randn(Point2f, 30)./ 6 .+( Point2f(0.5),)) 
end
scene = a.scene
plotlike = scene
all_flattened = Makie.flatten_plots(plotlike)
filter!(x -> x isa Union{Makie.Lines, Makie.Scatter, Makie.MeshScatter}, all_flattened)

datarect = Rect2f(data_limits(scene))

function get_pointcollection(plot::Makie.Lines)
    return [plot[1][]]
end

function get_pointcollection(plot::Makie.Scatter)
    return plot[1][] # scatters are individual points, so they are returned as points not lines
end

pointcollection = reduce(vcat, get_pointcollection.(all_flattened))

feature_collection = GeoInterface.FeatureCollection(GeoInterface.Feature.(pointcollection))

fc = GeoInterface.Feature.(pointcollection; properties = (;)) |> GeoInterface.FeatureCollection

Rasters.rasterize(count, $fc; size = (25, 25) #=to = (X(LinRange(0, 1, 500)), Y(LinRange(0, 1, 500)))=#, init = 0) |> heatmap
```

This is dog slow for any geometry on master but will try to loop and make it better...