### PR TITLE
fix warp memory driver compression error

### DIFF
--- a/ext/RastersArchGDALExt/gdal_source.jl
+++ b/ext/RastersArchGDALExt/gdal_source.jl
@@ -401,7 +401,7 @@ function _gdal_process_options(driver::AbstractString, options::Dict;
 )
     gdaldriver = AG.getdriver(driver)
     # set default compression
-    if !("COMPRESS" in keys(options)) && AG.validate(gdaldriver, ["COMPRESS=ZSTD"])
+    if driver != "MEM" && !("COMPRESS" in keys(options)) && AG.validate(gdaldriver, ["COMPRESS=ZSTD"])
         options["COMPRESS"] = "ZSTD"
     end
 


### PR DESCRIPTION
`warp` didn't work because the memory driver in use does not support the compress option. I applied an easy fix.