### PR TITLE
Updated error message when attempting to read a file without the appropriate backend.

### DIFF
--- a/src/sources/sources.jl
+++ b/src/sources/sources.jl
@@ -59,5 +59,5 @@ function _open(f, filename::AbstractString; source=_sourcetype(filename), kw...)
 end
 function _open(f, T::Type, filename::AbstractString; kw...)
     packagename = SOURCE2PACAKGENAME[T]
-    error("Rasters.jl requires backends to be loaded externally as of version 0.8. Run `import $packagename` to read $filename.")
+    error("Rasters.jl requires backends to be loaded externally as of version 0.8. Run `import $packagename` to read $filename")
 end

--- a/src/sources/sources.jl
+++ b/src/sources/sources.jl
@@ -59,5 +59,5 @@ function _open(f, filename::AbstractString; source=_sourcetype(filename), kw...)
 end
 function _open(f, T::Type, filename::AbstractString; kw...)
     packagename = SOURCE2PACAKGENAME[T]
-    error("Run `import $packagename` to read $filename")
+        error("Rasters.jl requires backends to be loaded externally as of version 0.8. Run `import $packagename` to read $filename.")
 end

--- a/src/sources/sources.jl
+++ b/src/sources/sources.jl
@@ -59,5 +59,5 @@ function _open(f, filename::AbstractString; source=_sourcetype(filename), kw...)
 end
 function _open(f, T::Type, filename::AbstractString; kw...)
     packagename = SOURCE2PACAKGENAME[T]
-    error("Rasters.jl requires backends to be loaded externally as of version 0.8. Run `import $packagename` to read $filename")
+    error("`Rasters.jl` requires backends to be loaded externally as of version 0.8. Run `import $packagename` to read $filename")
 end

--- a/src/sources/sources.jl
+++ b/src/sources/sources.jl
@@ -59,5 +59,5 @@ function _open(f, filename::AbstractString; source=_sourcetype(filename), kw...)
 end
 function _open(f, T::Type, filename::AbstractString; kw...)
     packagename = SOURCE2PACAKGENAME[T]
-        error("Rasters.jl requires backends to be loaded externally as of version 0.8. Run `import $packagename` to read $filename.")
+    error("Rasters.jl requires backends to be loaded externally as of version 0.8. Run `import $packagename` to read $filename.")
 end


### PR DESCRIPTION
The previous error message for reading rasters without an imported backend was confusing. The new message informs callers of the change and suggests the appropriate backend to use.

The error now reads, "Rasters.jl requires backends to be loaded externally as of version 0.8. Run `import $packagename` to read $filename"