### PR TITLE
Catch error in write to remove broken file

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -8,7 +8,14 @@ Keyword arguments are passed to the `write` method for the backend.
 function Base.write(
     filename::AbstractString, A::AbstractRaster; source=_sourcetype(filename), kw...
 )
-    write(filename, source, A; kw...)
+    try
+        write(filename, source, A; kw...)
+    catch e
+        if isfile(filename)
+            rm(filename)
+        end
+        rethrow(e)
+    end
 end
 Base.write(A::AbstractRaster; kw...) = write(filename(A), A; kw...)
 function Base.write(

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -289,6 +289,16 @@ end
             @test size2 > size1*1.8 # two variable 
             isfile(fn) && rm(fn)
 
+            # test erroring doesn't write file
+            fn = "test_broken.nc"
+            try 
+                write(fn, r1; deflatelevel="a")
+            catch e
+            end
+            @test !isfile(fn)
+            isfile(fn) && rm(fn)
+            
+
             @testset "non allowed values" begin
                 # TODO return this test when the changes in NCDatasets.jl settle
                 # @test_throws ArgumentError write(filename, convert.(Union{Missing,Float16}, geoA))


### PR DESCRIPTION
When the write command errors it still sometimes construct a broken file on disk.
This change should make sure, that  the write function would tidy up these broken files after faliure, because they are in the way for later analysis.

Do you think, that this is enough to capture all broken files?
Should this also be tested for other backends?

Locally I get some spurious failures which have nothing to do with the changes but are coming from some download time out errors. 
