### PR TITLE
enable all virtual file systems

### DIFF
--- a/ext/RastersArchGDALExt/gdal_source.jl
+++ b/ext/RastersArchGDALExt/gdal_source.jl
@@ -9,6 +9,35 @@ const GDAL_Y_LOCUS = Start()
 # drivers supporting the gdal Create() method to directly write to disk
 const GDAL_DRIVERS_SUPPORTING_CREATE = ("GTiff", "HDF4", "KEA", "netCDF", "PCIDSK", "Zarr", "MEM"#=...=#) 
 
+# order is equal to https://gdal.org/user/virtual_file_systems.html
+const GDAL_VIRTUAL_FILESYSTEMS = "/vsi" .* (
+    "zip",
+    "tar",
+    "gzip",
+    "7z",
+    "rar",
+    "curl",
+    "curl_streaming",
+    "s3",
+    "s3_streaming",
+    "gs",
+    "gs_streaming",
+    "az",
+    "az_streaming",
+    "adls",
+    "oss",
+    "oss_streaming",
+    "swift",
+    "swift_streaming",
+    "hdfs",
+    "webhdfs",
+    "stdin",
+    "stdout",
+    "mem",
+    "subfile",
+    "sparse",
+    )
+
 # Array ########################################################################
 
 function RA.FileArray(raster::AG.RasterDataset{T}, filename; kw...) where {T}
@@ -124,35 +153,7 @@ function RA._open(f, ::Type{GDALsource}, filename::AbstractString; write=false, 
         # Handle gdal virtual file systems
         # the respective string is prepended to the data source,
         # e.g. /vsicurl/https://...
-        # order is equal to https://gdal.org/user/virtual_file_systems.html
-        gdal_virtual_filesystems = "/vsi" .* (
-            "zip",
-            "tar",
-            "gzip",
-            "7z",
-            "rar",
-            "curl",
-            "curl_streaming",
-            "s3",
-            "s3_streaming",
-            "gs",
-            "gs_streaming",
-            "az",
-            "az_streaming",
-            "adls",
-            "oss",
-            "oss_streaming",
-            "swift",
-            "swift_streaming",
-            "hdfs",
-            "webhdfs",
-            "stdin",
-            "stdout",
-            "mem",
-            "subfile",
-            "sparse",
-            )
-        if length(filename) >= 8 && any(startswith.(filename, gdal_virtual_filesystems))
+        if length(filename) >= 8 && any(startswith.(filename, GDAL_VIRTUAL_FILESYSTEMS))
             nothing
         elseif RA._isurl(filename)
             filename = "/vsicurl/" * filename

--- a/ext/RastersArchGDALExt/gdal_source.jl
+++ b/ext/RastersArchGDALExt/gdal_source.jl
@@ -121,9 +121,38 @@ end
 
 function RA._open(f, ::Type{GDALsource}, filename::AbstractString; write=false, kw...)
     if !isfile(filename)
-        # Handle url filenames
-        # /vsicurl/ is added to urls for GDAL, /vsimem/ for in memory
-        if length(filename) >= 8 && filename[1:8] in ("/vsicurl", "/vsimem/")
+        # Handle gdal virtual file systems
+        # the respective string is prepended to the data source,
+        # e.g. /vsicurl/https://...
+        # order is equal to https://gdal.org/user/virtual_file_systems.html
+        gdal_virtual_filesystems = "/vsi" .* (
+            "zip",
+            "tar",
+            "gzip",
+            "7z",
+            "rar",
+            "curl",
+            "curl_streaming",
+            "s3",
+            "s3_streaming",
+            "gs",
+            "gs_streaming",
+            "az",
+            "az_streaming",
+            "adls",
+            "oss",
+            "oss_streaming",
+            "swift",
+            "swift_streaming",
+            "hdfs",
+            "webhdfs",
+            "stdin",
+            "stdout",
+            "mem",
+            "subfile",
+            "sparse",
+            )
+        if length(filename) >= 8 && any(startswith.(filename, gdal_virtual_filesystems))
             nothing
         elseif RA._isurl(filename)
             filename = "/vsicurl/" * filename


### PR DESCRIPTION
Hi! I wanted to use gdal's /vsitar virtual file system and found only checks for curl and mem, so I added the rest. I also modified the if condition a bit to use `startswith`. I haven't added any test; the best I could do is to provide a tar file and check with that. But I won't be able to check s3, az etc as I don't have any data there.