### PR TITLE
Fixed skipmissing bug

### DIFF
--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -35,7 +35,6 @@ end
 
 _missing(x, itr) = isequal(x, missingval(itr))
 _missing(x::Missing, itr) = true
-
 _missing(x::Nothing, itr) = false
 
 Base.IndexStyle(::Type{<:SkipMissingVal{T}}) where {T} = IndexStyle(T)

--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -34,7 +34,6 @@ function Base.iterate(itr::SkipMissingVal, state...)
 end
 
 _missing(x, itr) = isequal(x, missingval(itr))
-
 _missing(x::Missing, itr) = true
 
 _missing(x::Nothing, itr) = false

--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -38,9 +38,9 @@ function _missing(x::AbstractFloat, itr)
     if isnothing(missingval(itr))
         return false
     elseif isnan(missingval(itr))
-        return ismissing(x) || isnan(x)
+        return isnan(x)
     else
-        return ismissing(x) || x == missingval(itr)
+        return x == missingval(itr)
     end
 end
 

--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -37,7 +37,7 @@ _missing(x, itr) = isequal(x, missingval(itr))
 
 _missing(x::Missing, itr) = true
 
-_missing(x::Nothing, itr) = true
+_missing(x::Nothing, itr) = false
 
 Base.IndexStyle(::Type{<:SkipMissingVal{T}}) where {T} = IndexStyle(T)
 Base.eachindex(itr::SkipMissingVal) =

--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -33,21 +33,11 @@ function Base.iterate(itr::SkipMissingVal, state...)
     item, state
 end
 
-_missing(x, itr) = x == missingval(itr)
+_missing(x, itr) = isequal(x, missingval(itr))
 
 _missing(x::Missing, itr) = true
 
 _missing(x::Nothing, itr) = true
-
-function _missing(x::AbstractFloat, itr)
-    if isnothing(missingval(itr))
-        return false
-    elseif isnan(missingval(itr))
-        return isnan(x)
-    else
-        return x == missingval(itr)
-    end
-end
 
 Base.IndexStyle(::Type{<:SkipMissingVal{T}}) where {T} = IndexStyle(T)
 Base.eachindex(itr::SkipMissingVal) =

--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -35,7 +35,9 @@ end
 
 _missing(x, itr) = ismissing(x) || x == missingval(itr)  # mind the order, as comparison with missing returns missing
 function _missing(x::AbstractFloat, itr)
-    if isnan(missingval(itr))
+    if isnothing(missingval(itr))
+        return false
+    elseif isnan(missingval(itr))
         return ismissing(x) || isnan(x)
     else
         return ismissing(x) || x == missingval(itr)

--- a/src/skipmissing.jl
+++ b/src/skipmissing.jl
@@ -33,7 +33,12 @@ function Base.iterate(itr::SkipMissingVal, state...)
     item, state
 end
 
-_missing(x, itr) = ismissing(x) || x == missingval(itr)  # mind the order, as comparison with missing returns missing
+_missing(x, itr) = x == missingval(itr)
+
+_missing(x::Missing, itr) = true
+
+_missing(x::Nothing, itr) = true
+
 function _missing(x::AbstractFloat, itr)
     if isnothing(missingval(itr))
         return false

--- a/test/array.jl
+++ b/test/array.jl
@@ -115,8 +115,8 @@ end
     nraster = Raster([1 1; missing nothing], (X, Y); missingval=nothing)
     @test length(collect(skipmissing(fraster))) == 4 # Keeps NaN
     @test length(collect(skipmissing(mraster))) == 3 # Drops missing
-    @test length(collect(skipmissing(iraster))) == 3 # Test with integers
-    @test length(collect(skipmissing(nraster))) == 2 # Drops nothing
+    @test length(collect(skipmissing(iraster))) == 3 # Drops missing (integers)
+    @test length(collect(skipmissing(nraster))) == 3 # Keeps nothing (integer)
 
     # Confirm that missingvals are removed by value, even when types don't match
     r = Raster(ones(Int16, 8, 8), (X,Y); missingval = Int16(-9999))

--- a/test/array.jl
+++ b/test/array.jl
@@ -111,8 +111,12 @@ end
     # Test missingval=nothing
     fraster = Raster([NaN 1.0; 2.0 NaN], (X, Y); missingval=nothing)
     mraster = Raster([NaN 1.0; missing NaN], (X, Y); missingval=nothing)
+    iraster = Raster([1 1; missing 2], (X, Y); missingval=nothing)
+    nraster = Raster([1 1; missing nothing], (X, Y); missingval=nothing)
     @test length(collect(skipmissing(fraster))) == 4 # Keeps NaN
     @test length(collect(skipmissing(mraster))) == 3 # Drops missing
+    @test length(collect(skipmissing(iraster))) == 3 # Test with integers
+    @test length(collect(skipmissing(nraster))) == 2 # Drops nothing
 
     # Confirm that missingvals are removed by value, even when types don't match
     r = Raster(ones(Int16, 8, 8), (X,Y); missingval = Int16(-9999))

--- a/test/array.jl
+++ b/test/array.jl
@@ -92,12 +92,14 @@ end
 end
 
 @testset "skipmissing uses missingval" begin
+    # Test missingval=NaN
     raster = Raster([NaN 1.0; 2.0 NaN], (X, Y); missingval=NaN)
     @test collect(skipmissing(raster)) == [2.0, 1.0]
     @test collect(keys(skipmissing(raster))) == [CartesianIndex(2, 1), CartesianIndex(1, 2)]
     @test collect(eachindex(skipmissing(raster))) == [2, 3]
     @test_throws MissingException skipmissing(raster)[1]
     @test skipmissing(raster)[2] == 2.0
+
     # It skips actual missing values as well
     mraster = Raster([NaN 1.0; missing NaN], (X, Y); missingval=NaN)
     @test collect(skipmissing(mraster)) == [1.0]
@@ -106,6 +108,13 @@ end
     @test skipmissing(mraster)[3] == 1.0
     @test_throws MissingException skipmissing(mraster)[2]
 
+    # Test missingval=nothing
+    fraster = Raster([NaN 1.0; 2.0 NaN], (X, Y); missingval=nothing)
+    mraster = Raster([NaN 1.0; missing NaN], (X, Y); missingval=nothing)
+    @test length(collect(skipmissing(fraster))) == 4 # Keeps NaN
+    @test length(collect(skipmissing(mraster))) == 3 # Drops missing
+
+    # Confirm that missingvals are removed by value, even when types don't match
     r = Raster(ones(Int16, 8, 8), (X,Y); missingval = Int16(-9999))
     r[1:4, 1:4] .= -9999
     r = float.(r)


### PR DESCRIPTION
There was a bug when calling `skipmissing` on a raster whose elements are floats and for which missingval = nothing.

The following code segment resulted in calling `isnan` on a `Nothing` value, which throws a `MethodError`.
```julia
function _missing(x::AbstractFloat, itr)
    if isnan(missingval(itr))
        return ismissing(x) || isnan(x)
    else
        return ismissing(x) || x == missingval(itr)
    end
end
```