### PR TITLE
Set eltype for selection of missingval in resample

### DIFF
--- a/ext/RastersArchGDALExt/gdal_source.jl
+++ b/ext/RastersArchGDALExt/gdal_source.jl
@@ -483,6 +483,7 @@ function _gdalsetproperties!(dataset::AG.Dataset, dims::Tuple, missingval)
     # Set the nodata value. GDAL can't handle missing. We could choose a default,
     # but we would need to do this for all possible types. `nothing` means
     # there is no missing value.
+    T = eltype(AG.getband(dataset, 1))
     if !isnothing(missingval)
         if ismissing(missingval)
             missingval = RA._writeable_missing(T)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -454,4 +454,8 @@ end
         @test crs(nocrs) == nothing
         @test_warn "does not have crs" resample(nocrs; crs=output_crs, method)
     end
+
+    @testset "resample with missingval==missing"
+        ras = Raster(rand(X(1:10), Y(1:10), missingval=missing))
+        @test resample(ras, to=ras) == ras
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -455,7 +455,8 @@ end
         @test_warn "does not have crs" resample(nocrs; crs=output_crs, method)
     end
 
-    @testset "resample with missingval==missing"
+    @testset "resample with missingval==missing" begin 
         ras = Raster(rand(X(1:10), Y(1:10), missingval=missing))
         @test resample(ras, to=ras) == ras
+    end
 end


### PR DESCRIPTION
The test case is currently broken, but this needs more investigation.
I would have expected that the resampling of the data to the same extent with nearest neighbour should be a no-op.
Apparently this switches the orientation of the Y Axis around and therefore the test  case currently fails.
This should close #509 .

