### PR TITLE
Fix gdal drivers and options

### DIFF
--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -322,7 +322,8 @@ gdalpath = maybedownload(url)
                     rm(filename)
                 end
             end
-            @test_throws ArgumentError write(filename, gdalarray; driver="GTiff", options=Dict("COMPRESS"=>"FOOBAR"))
+            filename_gtiff2 = tempname() * ".tif"
+            @test_throws ArgumentError write(filename_gtiff2, gdalarray; driver="GTiff", options=Dict("COMPRESS"=>"FOOBAR"))
         end
 
         @testset "resave current" begin


### PR DESCRIPTION
Because of the COG/GeoTIFF mess in default drivers, options were not working properly. This PR cleans up and standardises drivers and options.

@kongdd check out this branch if you want to try it. I still need to write tests and I'm not sure it works in all cases, for GeoTiff it only seems to be using the BLOCKYSIZE. You can specify `diver="COG"` and it will use the "BLOCKSIZE" for both.

Closes #527