### PR TITLE
Make RasterDataSources use tmp instead of . in docs

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -25,7 +25,7 @@ jobs:
         run: julia --project=docs -e 'using Pkg; pkg"dev ."; Pkg.instantiate()'
       - name: Build and deploy
         env:
-          RASTERDATASOURCES_PATH: "."
+          RASTERDATASOURCES_PATH: "/tmp"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
           GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988


### PR DESCRIPTION
This should stop the docs to put the data sources into the gh-pages branch.

I hope, that this is going to make the size of the docs significantly smaller.
