### PR TITLE
Better extract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
-          # - windows-latest
+          # - macOS-latest
+          - windows-latest
         arch:
           - x64
     steps:

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -16,7 +16,7 @@ sliced arrays or stacks will be returned instead of single values.
 # Keywords
 
 - `geometry`: include a `:geometry` column with the corresponding points for each value, `true` by default.
-- `index`: include a column of the `CartesianIndex` for each value, `false` by default.
+- `index`: include an `:index` column of the `CartesianIndex` for each value, `false` by default.
 - `names`: `Tuple` of `Symbol` corresponding to layers of a `RasterStack`. All layers by default.
 - `skipmissing`: skip missing points automatically.
 - `atol`: a tolorerance for floating point lookup values for when the `LookupArray`

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -48,6 +48,9 @@ collect(extract(st, pnts; skipmissing=true))
  (geometry = (0.52, 40.37), bio1 = missing, bio3 = missing, bio5 = missing, bio7 = missing, bio12 = missing)
  (geometry = (0.32, 40.24), bio1 = 16.321388f0, bio3 = 41.659454f0, bio5 = 30.029825f0, bio7 = 25.544561f0, bio12 = 480.0f0)
 ```
+
+Note: passing in arrays, geometry collections or feature collections 
+containing a mix of points and other geometries has undefined results.
 """
 function extract end
 function extract(x::RasterStackOrArray, data;
@@ -79,7 +82,7 @@ end
 function _extract(A::RasterStackOrArray, ::GI.AbstractFeatureTrait, feature; kw...)
     _extract(A, GI.geometry(feature); kw...)
 end
-function _extract(A::RasterStackOrArray, ::GI.FeatureCollection, fc; kw...)
+function _extract(A::RasterStackOrArray, ::GI.FeatureCollectionTrait, fc; kw...)
     # Fall back to the Array/iterator method for feature collections
     _extract(A, [GI.geometry(f) for f in GI.getfeature(fc)]; kw...)
 end

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -79,6 +79,10 @@ end
 function _extract(A::RasterStackOrArray, ::GI.AbstractFeatureTrait, feature; kw...)
     _extract(A, GI.geometry(feature); kw...)
 end
+function _extract(A::RasterStackOrArray, ::GI.FeatureCollection, fc; kw...)
+    # Fall back to the Array/iterator method for feature collections
+    _extract(A, [GI.geometry(f) for f in GI.getfeature(fc)]; kw...)
+end
 function _extract(A::RasterStackOrArray, ::GI.AbstractMultiPointTrait, geom; skipmissing=false, kw...)
     rows = (_extract_point(A, g; kw...) for g in GI.getpoint(geom))
     return skipmissing ? collect(_skip_missing_rows(rows)) : collect(rows)

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -75,7 +75,11 @@ _extract(T, A::RasterStackOrArray, ::Nothing, geom; kw...) = throw(ArgumentError
 function _extract(T, A::RasterStackOrArray, ::Nothing, geoms::AbstractArray; names, skipmissing=false, kw...)
     # Handle empty / all missing cases
     (length(geoms) > 0 && any(!ismissing, geoms)) || return T[]
-    geom1 = first(Base.skipmissing(geoms)) # TODO: will fail if `geoms` is empty or all missing
+    # Handle cases with some invalid geometries
+    invalid_geom_idx = findfirst(g -> !ismissing(g) && GI.geomtrait(g) === nothing, geoms)
+    invalid_geom_idx === nothing || throw(ArgumentError("$(geoms[invalid_geom_idx]) is not a valid GeoInterface.jl geometry"))
+
+    geom1 = first(Base.skipmissing(geoms))
     trait1 = GI.trait(geom1)
     # We need to split out points from other geoms
     # TODO this will fail with mixed point/geom vectors

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -55,6 +55,7 @@ function extract(x::RasterStackOrArray, data;
 )
     _extract(x, data; dims, names, kw...)
 end
+
 _extract(A::RasterStackOrArray, point::Missing; kw...) = missing
 _extract(A::RasterStackOrArray, geom; kw...) = _extract(A, GI.geomtrait(geom), geom; kw...)
 function _extract(A::RasterStackOrArray, ::Nothing, geoms; skipmissing=false, kw...)

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -56,7 +56,7 @@ function extract end
 function extract(x::RasterStackOrArray, data;
     dims=DD.dims(x, DEFAULT_POINT_ORDER), names=_names(x), kw...
 )
-    _extract(x, data; dims, names, kw...)
+    _extract(x, data; dims, names=NamedTuple{names}(names), kw...)
 end
 
 function _extract(A::RasterStackOrArray, geom::Missing; names, kw...)
@@ -172,5 +172,5 @@ end
     end
 end
 
-_names(A::AbstractRaster) = NamedTuple{(Symbol(name(A)),)}((Symbol(name(A)),))
-_names(A::AbstractRasterStack) = NamedTuple{keys(A)}(keys(A))
+_names(A::AbstractRaster) = (Symbol(name(A)),)
+_names(A::AbstractRasterStack) = keys(A)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -355,6 +355,7 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
         @test extract(rast, []; geometry=false) == NamedTuple{(:test,),Tuple{Missing}}[]
         # Missing coord errors
         @test_throws ArgumentError extract(rast, [(0.0, missing), (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)])
+        @test_throws ArgumentError extract(rast, [(X=0.0, Y=missing), (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)])
     end
 
     @testset "from stack" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -348,6 +348,9 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
             (geometry = (9.0, 0.1), index = CartesianIndex(1, 1), test = 1)
             (geometry = (10.0, 0.1), index = CartesianIndex(2, 1), test = 3)
         ]                                                         
+        # Empty geoms
+        @test extract(rast, []) == NamedTuple{(:geometry, :test),Tuple{Missing,Missing}}[]
+        @test extract(rast, []; geometry=false) == NamedTuple{(:test,),Tuple{Missing}}[]
     end
 
     @testset "from stack" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -2,6 +2,8 @@ using Rasters, Test, ArchGDAL, ArchGDAL.GDAL, Dates, Statistics, DataFrames, Ext
 import GeoInterface
 using Rasters.LookupArrays, Rasters.Dimensions 
 using Rasters: bounds
+using Rasters
+using ArchGDAL
 
 include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
 
@@ -256,6 +258,7 @@ end
 # Polygon(::Val{:ArchGDAL}, values) = ArchGDAL.createpolygon(values)
 
 createpoint(args...) = ArchGDAL.createpoint(args...)
+
 createfeature(x::Tuple{<:Any,<:Any}) = NamedTuple{(:geometry,:test)}(x)
 createfeature(x::Tuple{<:Any,<:Any,<:Any}) = NamedTuple{(:geometry,:test,:test2)}(x)
 createfeature(::Missing) = missing
@@ -264,27 +267,108 @@ createfeature(::Missing) = missing
     dimz = (X(9.0:1.0:10.0), Y(0.1:0.1:0.2))
     ga = Raster([1 2; 3 4], dimz; name=:test, missingval=missing)
     ga2 = Raster([5 6; 7 8], dimz; name=:test2, missingval=missing)
+    ga_m = Raster([1 2; 3 missing], dimz; name=:test, missingval=missing)
     st = RasterStack(ga, ga2)
     @testset "from Raster" begin
         # Tuple points
-        @test all(extract(ga, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]) .=== 
-                  createfeature.([missing, ((9.0, 0.1), 1), ((9.0, 0.2), 2), ((10.0, 0.3), missing)]))
+        @test all(collect(extract(ga, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)])) .=== [
+            (geometry = missing, test = missing)
+            (geometry = (9.0, 0.1), test = 1)
+            (geometry = (9.0, 0.2), test = 2)
+            (geometry = (10.0, 0.3), test = missing)
+        ])
+        @test all(collect(extract(ga_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true)) .=== [
+            (geometry = (9.0, 0.1), test = 1)
+            (geometry = (9.0, 0.2), test = 2)
+        ])
+        @test all(collect(extract(ga_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false)) .=== [
+            (test = 1,)
+            (test = 2,)
+        ])
+        @test all(collect(extract(ga_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false, index=true)) .=== [
+            (index = (1, 1), test = 1,)
+            (index = (1, 2), test = 2,)
+        ])
         # NamedTuple (reversed) points
-        @test all(extract(ga, [missing, (Y=0.1, X=9.0), (Y=0.2, X=10.0), (Y=0.3, X=10.0)]) |> collect .=== 
-                  createfeature.([missing, ((Y=0.1, X=9.0), 1), ((Y=0.2, X=10.0), 4), ((Y=0.3, X=10.0), missing)]))
+        @test all(collect(extract(ga, [missing, (Y=0.1, X=9.0), (Y=0.2, X=10.0), (Y=0.3, X=10.0)])) .=== [
+            (geometry = missing, test = missing)
+            (geometry = (Y = 0.1, X = 9.0), test = 1)
+            (geometry = (Y = 0.2, X = 10.0), test = 4)
+            (geometry = (Y = 0.3, X = 10.0), test = missing)
+        ])
         # Vector points
-        @test all(extract(ga, [[9.0, 0.1], [10.0, 0.2]]) .== createfeature.([([9.0, 0.1], 1), ([10.0, 0.2], 4)]))
+        @test all(collect(extract(ga, [[9.0, 0.1], [10.0, 0.2]])) .== [
+            (geometry = [9.0, 0.1], test = 1)
+            (geometry = [10.0, 0.2], test = 4)
+        ])
         # ArchGDAL equality is broken
         # @test all(extract(ga, ArchGDAL.createmultipoint([[0.1, 9.0], [0.2, 10.0], [0.3, 10.0]])) .==
                   # createfeature.([(createpoint(0.1, 9.0), 1), (createpoint(0.2, 10.0), 4), (createpoint(0.3, 10.0), missing)]))
         # Extract a polygon
         p = ArchGDAL.createpolygon([[[8.0, 0.0], [11.0, 0.0], [11.0, 0.4], [8.0, 0.0]]])
-        @test all(extract(ga, p) .=== 
-            createfeature.([((X=9.0, Y=0.1), 1), ((X=10.0, Y=0.1), 3), ((X=10.0, Y=0.2), 4)]))
+        @test all(collect(extract(ga, p)) .=== 
+            createfeature.([((9.0, 0.1), 1), ((10.0, 0.1), 3), ((10.0, 0.2), 4)]))
+
+        @test collect(extract(ga, p; geometry=false)) == [
+            (test = 1,)
+            (test = 3,)
+            (test = 4,)
+        ]
+        @test collect(extract(ga, p; geometry=false, index=true)) == [
+            (index = CartesianIndex(1, 1), test = 1)
+            (index = CartesianIndex(2, 1), test = 3)
+            (index = CartesianIndex(2, 2), test = 4)
+        ]
+        @test collect(extract(ga, p)) == [
+            (geometry = (9.0, 0.1), test = 1)
+            (geometry = (10.0, 0.1), test = 3)
+            (geometry = (10.0, 0.2), test = 4)
+        ]
+        @test collect(extract(ga, p; index=true)) == [
+             (geometry = (9.0, 0.1), index = CartesianIndex(1, 1), test = 1)
+             (geometry = (10.0, 0.1), index = CartesianIndex(2, 1), test = 3)
+             (geometry = (10.0, 0.2), index = CartesianIndex(2, 2), test = 4)
+        ]
+        @test collect(extract(ga, p; skipmissing=true, geometry=false)) == [
+            (test = 1,)
+            (test = 3,)
+            (test = 4,)
+        ]                                                         
+        @test collect(extract(ga, p; skipmissing=true, geometry=false, index=true)) == [
+            (index = CartesianIndex(1, 1), test = 1)
+            (index = CartesianIndex(2, 1), test = 3)
+            (index = CartesianIndex(2, 2), test = 4)
+        ]                                                         
+        @test collect(extract(ga, p; skipmissing=true)) == [
+            (geometry = (9.0, 0.1), test = 1)
+            (geometry = (10.0, 0.1), test = 3)
+            (geometry = (10.0, 0.2), test = 4)
+        ]                                                         
+        @test collect(extract(ga, p; skipmissing=true, index=true)) == [
+            (geometry = (9.0, 0.1), index = CartesianIndex(1, 1), test = 1)
+            (geometry = (10.0, 0.1), index = CartesianIndex(2, 1), test = 3)
+            (geometry = (10.0, 0.2), index = CartesianIndex(2, 2), test = 4)
+        ]                                                         
     end
     @testset "from stack" begin
-        @test all(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]) |> collect .===
-                  createfeature.([missing, ((9.0, 0.1), 1, 5), ((10.0, 0.2), 4, 8), ((10.0, 0.3), missing, missing)]))
+        @test all(collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)])) .=== [
+            (geometry = missing, test = missing, test2 = missing)
+            (geometry = (9.0, 0.1), test = 1, test2 = 5)
+            (geometry = (10.0, 0.2), test = 4, test2 = 8)
+            (geometry = (10.0, 0.3), test = missing, test2 = missing)
+        ])
+        @test all(collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true)) .=== [
+            (geometry = (9.0, 0.1), test = 1, test2 = 5)
+            (geometry = (10.0, 0.2), test = 4, test2 = 8)
+        ])
+        @test all(collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false)) .=== [
+            (test = 1, test2 = 5)
+            (test = 4, test2 = 8)
+        ])
+        @test all(collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false, index=true)) .=== [
+            (index = (1, 1), test = 1, test2 = 5)
+            (index = (2, 2), test = 4, test2 = 8)
+        ])
     end
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -259,97 +259,89 @@ end
 
 createpoint(args...) = ArchGDAL.createpoint(args...)
 
-createfeature(x::Tuple{<:Any,<:Any}) = NamedTuple{(:geometry,:test)}(x)
-createfeature(x::Tuple{<:Any,<:Any,<:Any}) = NamedTuple{(:geometry,:test,:test2)}(x)
-createfeature(::Missing) = missing
-
 @testset "extract" begin
     dimz = (X(9.0:1.0:10.0), Y(0.1:0.1:0.2))
-    ga = Raster([1 2; 3 4], dimz; name=:test, missingval=missing)
-    ga2 = Raster([5 6; 7 8], dimz; name=:test2, missingval=missing)
-    ga_m = Raster([1 2; 3 missing], dimz; name=:test, missingval=missing)
-    st = RasterStack(ga, ga2)
+    rast = Raster([1 2; 3 4], dimz; name=:test, missingval=missing)
+    rast2 = Raster([5 6; 7 8], dimz; name=:test2, missingval=missing)
+    rast_m = Raster([1 2; 3 missing], dimz; name=:test, missingval=missing)
+    st = RasterStack(rast, rast2)
     @testset "from Raster" begin
         # Tuple points
-        @test all(collect(extract(ga, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)])) .=== [
+        @test all(collect(extract(rast, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)])) .=== [
             (geometry = missing, test = missing)
             (geometry = (9.0, 0.1), test = 1)
             (geometry = (9.0, 0.2), test = 2)
             (geometry = (10.0, 0.3), test = missing)
         ])
-        @test all(collect(extract(ga_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true)) .=== [
+        @test all(collect(extract(rast_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true)) .=== [
             (geometry = (9.0, 0.1), test = 1)
             (geometry = (9.0, 0.2), test = 2)
         ])
-        @test all(collect(extract(ga_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false)) .=== [
+        @test all(collect(extract(rast_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false)) .=== [
             (test = 1,)
             (test = 2,)
         ])
-        @test all(collect(extract(ga_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false, index=true)) .=== [
+        @test all(collect(extract(rast_m, [missing, (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false, index=true)) .=== [
             (index = (1, 1), test = 1,)
             (index = (1, 2), test = 2,)
         ])
         # NamedTuple (reversed) points
-        @test all(collect(extract(ga, [missing, (Y=0.1, X=9.0), (Y=0.2, X=10.0), (Y=0.3, X=10.0)])) .=== [
+        @test all(collect(extract(rast, [missing, (Y=0.1, X=9.0), (Y=0.2, X=10.0), (Y=0.3, X=10.0)])) .=== [
             (geometry = missing, test = missing)
             (geometry = (Y = 0.1, X = 9.0), test = 1)
             (geometry = (Y = 0.2, X = 10.0), test = 4)
             (geometry = (Y = 0.3, X = 10.0), test = missing)
         ])
         # Vector points
-        @test all(collect(extract(ga, [[9.0, 0.1], [10.0, 0.2]])) .== [
+        @test all(collect(extract(rast, [[9.0, 0.1], [10.0, 0.2]])) .== [
             (geometry = [9.0, 0.1], test = 1)
             (geometry = [10.0, 0.2], test = 4)
         ])
-        # ArchGDAL equality is broken
-        # @test all(extract(ga, ArchGDAL.createmultipoint([[0.1, 9.0], [0.2, 10.0], [0.3, 10.0]])) .==
-                  # createfeature.([(createpoint(0.1, 9.0), 1), (createpoint(0.2, 10.0), 4), (createpoint(0.3, 10.0), missing)]))
         # Extract a polygon
         p = ArchGDAL.createpolygon([[[8.0, 0.0], [11.0, 0.0], [11.0, 0.4], [8.0, 0.0]]])
-        @test all(collect(extract(ga, p)) .=== 
-            createfeature.([((9.0, 0.1), 1), ((10.0, 0.1), 3), ((10.0, 0.2), 4)]))
-
-        @test collect(extract(ga, p; geometry=false)) == [
-            (test = 1,)
-            (test = 3,)
-            (test = 4,)
-        ]
-        @test collect(extract(ga, p; geometry=false, index=true)) == [
-            (index = CartesianIndex(1, 1), test = 1)
-            (index = CartesianIndex(2, 1), test = 3)
-            (index = CartesianIndex(2, 2), test = 4)
-        ]
-        @test collect(extract(ga, p)) == [
+        @test all(collect(extract(rast_m, p)) .=== [
             (geometry = (9.0, 0.1), test = 1)
             (geometry = (10.0, 0.1), test = 3)
-            (geometry = (10.0, 0.2), test = 4)
-        ]
-        @test collect(extract(ga, p; index=true)) == [
+            (geometry = (10.0, 0.2), test = missing)
+        ])
+        @test all(collect(extract(rast_m, p; geometry=false)) .=== [
+            (test = 1,)
+            (test = 3,)
+            (test = missing,)
+        ])
+        @test all(collect(extract(rast_m, p; geometry=false, index=true)) .=== [
+            (index = CartesianIndex(1, 1), test = 1)
+            (index = CartesianIndex(2, 1), test = 3)
+            (index = CartesianIndex(2, 2), test = missing)
+        ])
+        @test all(collect(extract(rast_m, p)) .=== [
+            (geometry = (9.0, 0.1), test = 1)
+            (geometry = (10.0, 0.1), test = 3)
+            (geometry = (10.0, 0.2), test = missing)
+        ])
+        @test all(collect(extract(rast_m, p; index=true)) .=== [
              (geometry = (9.0, 0.1), index = CartesianIndex(1, 1), test = 1)
              (geometry = (10.0, 0.1), index = CartesianIndex(2, 1), test = 3)
-             (geometry = (10.0, 0.2), index = CartesianIndex(2, 2), test = 4)
-        ]
-        @test collect(extract(ga, p; skipmissing=true, geometry=false)) == [
+             (geometry = (10.0, 0.2), index = CartesianIndex(2, 2), test = missing)
+        ])
+        @test collect(extract(rast_m, p; skipmissing=true, geometry=false)) == [
             (test = 1,)
             (test = 3,)
-            (test = 4,)
         ]                                                         
-        @test collect(extract(ga, p; skipmissing=true, geometry=false, index=true)) == [
+        @test collect(extract(rast_m, p; skipmissing=true, geometry=false, index=true)) == [
             (index = CartesianIndex(1, 1), test = 1)
             (index = CartesianIndex(2, 1), test = 3)
-            (index = CartesianIndex(2, 2), test = 4)
         ]                                                         
-        @test collect(extract(ga, p; skipmissing=true)) == [
+        @test collect(extract(rast_m, p; skipmissing=true)) == [
             (geometry = (9.0, 0.1), test = 1)
             (geometry = (10.0, 0.1), test = 3)
-            (geometry = (10.0, 0.2), test = 4)
         ]                                                         
-        @test collect(extract(ga, p; skipmissing=true, index=true)) == [
+        @test collect(extract(rast_m, p; skipmissing=true, index=true)) == [
             (geometry = (9.0, 0.1), index = CartesianIndex(1, 1), test = 1)
             (geometry = (10.0, 0.1), index = CartesianIndex(2, 1), test = 3)
-            (geometry = (10.0, 0.2), index = CartesianIndex(2, 2), test = 4)
         ]                                                         
     end
+
     @testset "from stack" begin
         @test all(collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)])) .=== [
             (geometry = missing, test = missing, test2 = missing)
@@ -357,18 +349,18 @@ createfeature(::Missing) = missing
             (geometry = (10.0, 0.2), test = 4, test2 = 8)
             (geometry = (10.0, 0.3), test = missing, test2 = missing)
         ])
-        @test all(collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true)) .=== [
+        @test collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true)) == [
             (geometry = (9.0, 0.1), test = 1, test2 = 5)
             (geometry = (10.0, 0.2), test = 4, test2 = 8)
-        ])
-        @test all(collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false)) .=== [
+        ]
+        @test collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false)) == [
             (test = 1, test2 = 5)
             (test = 4, test2 = 8)
-        ])
-        @test all(collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false, index=true)) .=== [
+        ]
+        @test collect(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false, index=true)) == [
             (index = (1, 1), test = 1, test2 = 5)
             (index = (2, 2), test = 4, test2 = 8)
-        ])
+        ]
     end
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -355,6 +355,7 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
         @test extract(rast, []; geometry=false) == NamedTuple{(:test,),Tuple{Missing}}[]
         # Missing coord errors
         @test_throws ArgumentError extract(rast, [(0.0, missing), (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)])
+        @test_throws ArgumentError extract(rast, [(9.0, 0.1), (0.0, missing), (9.0, 0.2), (10.0, 0.3)])
         @test_throws ArgumentError extract(rast, [(X=0.0, Y=missing), (9.0, 0.1), (9.0, 0.2), (10.0, 0.3)])
     end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -372,6 +372,13 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
             (index = (1, 1), test = 1, test2 = 5)
             (index = (2, 2), test = 4, test2 = 8)
         ]
+        # Subset with `names`
+        @test all(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; names=(:test2,)) .=== [
+            (geometry = missing, test2 = missing)
+            (geometry = (9.0, 0.1), test2 = 5)
+            (geometry = (10.0, 0.2), test2 = 8)
+            (geometry = (10.0, 0.3), test2 = missing)
+        ])
     end
 end
 


### PR DESCRIPTION
This PR mostly adds new keywords to `extract`

@tiemvanderdeure feel like reviewing this thing? 

I made it return a vector - this isn't breaking as its still an iterable and we never promised the exact type or iterable.

I took the opportunity to polish the (pretty basic) implementation a little. As well as the new keywords, `extract` now properly handles flattening multiple polygons/feature collections/nested vectors of geoms so you always get a single "table" return value, and handles empty or all-missing inputs. The only known bug is mixed points and geometries in one vector or will fail. This is noted in the doc, and its kinda rare and not worth the effort right now. 

Also once I squash the commits together you wont just be on that one empty commit but the whole thing, its just to get your name on the list.