### PR TITLE
Bump patch version to 0.9.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rasters"
 uuid = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
This would enable to use NCDatasets 0.13 from the latest Rasters release.

