### PR TITLE
Fix writing GDAL "Points" on reversed axes

### DIFF
--- a/test/methods.jl
+++ b/test/methods.jl
@@ -441,7 +441,7 @@ end
         @test all(extended .=== ga) 
         @test all(extended_r .=== ga_r)
         extended_d = extend(cropped; to=ga, filename="extended.tif")
-        @test all(splat(==), zip(lookup(extended_d), lookup(extended)))
+        @test all(map(==, lookup(extended_d), lookup(extended)))
 
         @testset "to polygons" begin
             A1 = Raster(zeros(X(-20:-5; sampling=Points()), Y(0:30; sampling=Points())))

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -438,9 +438,10 @@ end
         @test all(cropped_r .=== trimmed_r)
         extended = extend(cropped, ga)[1]
         extended_r = extend(cropped_r; to=ga_r)
-        extended_d = extend(cropped; to=ga, filename="extended.tif")
         @test all(extended .=== ga) 
         @test all(extended_r .=== ga_r)
+        extended_d = extend(cropped; to=ga, filename="extended.tif")
+        @test all(splat(==), zip(lookup(extended_d), lookup(extended)))
 
         @testset "to polygons" begin
             A1 = Raster(zeros(X(-20:-5; sampling=Points()), Y(0:30; sampling=Points())))

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -263,9 +263,8 @@ gdalpath = maybedownload(url)
     @testset "write" begin
         gdalarray = Raster(gdalpath; name=:test);
 
-        @testset "2d" begin
+        @testset "2d asc" begin
             filename = tempname() * ".asc"
-            gdalarray
             @time write(filename, gdalarray)
             saved1 = Raster(filename);
             @test all(saved1 .== gdalarray)
@@ -275,6 +274,30 @@ gdalpath = maybedownload(url)
             @test missingval(saved1) === missingval(gdalarray)
             @test refdims(saved1) == refdims(gdalarray)
             rm(filename)
+        end
+
+        @testset "2d tif" begin
+            @testset "Intervals" begin
+                filename = tempname() * ".tif"
+                @time write(filename, gdalarray)
+                saved1 = Raster(filename);
+                @test all(saved1 .== gdalarray)
+                @test lookup(saved1) == lookup(gdalarray)
+                @test missingval(saved1) === missingval(gdalarray)
+                @test refdims(saved1) == refdims(gdalarray)
+                rm(filename)
+            end
+            @testset "Points" begin
+                filename = tempname() * ".tif"
+                gdalarray_points = set(gdalarray, X => Points, Y => Points)
+                @time write(filename, gdalarray_points)
+                saved1 = Raster(filename);
+                @test all(saved1 .== gdalarray_points)
+                @test lookup(saved1) == lookup(gdalarray_points)
+                @test missingval(saved1) === missingval(gdalarray_points)
+                @test refdims(saved1) == refdims(gdalarray_points)
+                rm(filename)
+            end
         end
 
         @testset "3d, with subsetting" begin


### PR DESCRIPTION
A bug had slipped into `"Points"` axis values in round trip read/write due to not properly testing it.

This PR fixes and tests that points round-trip correctly.