### PR TITLE
Fixed `extract` bug for `RasterStack`

### DIFF
--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -128,7 +128,7 @@ _extract(T, x::RasterStackOrArray, trait::GI.PointTrait, point; kw...) =
 
 @inline _skip_missing_rows(rows) = Iterators.filter(row -> !any(ismissing, row), rows)
 
-@inline _prop_nt(st::AbstractRasterStack, I, names::NamedTuple{K}) where K = t[I][K]
+@inline _prop_nt(st::AbstractRasterStack, I, names::NamedTuple{K}) where K = st[I][K]
 @inline _prop_nt(A::AbstractRaster, I, names::NamedTuple{K}) where K = NamedTuple{K}((A[I],))
 
 # Extract a single point


### PR DESCRIPTION
Attempting to call `extract` on a `RasterStack` gives the following error:

```julia
ERROR: UndefVarError: `t` not defined
```

The issue seems to be in methods/extract.jl:131

```julia
@inline _prop_nt(st::AbstractRasterStack, I, names::NamedTuple{K}) where K = t[I][K]
```

Which I fixed with the following:

```julia
@inline _prop_nt(st::AbstractRasterStack, I, names::NamedTuple{K}) where K = st[I][K]
```