### PR TITLE
fix cellsize

### DIFF
--- a/ext/RastersArchGDALExt/cellsize.jl
+++ b/ext/RastersArchGDALExt/cellsize.jl
@@ -48,9 +48,8 @@ function _area_from_coords(transform::ArchGDAL.CoordTransform, ::GI.LinearRingTr
     return _area_from_rads(GI.LinearRing(points))
 end
 
-function cellsize(dims::DimTuple)
-    xbnds, ybnds = DimensionalData.intervalbounds(dims)
-    # take CRS from Y if it has crs, else from X
+function cellsize(dims::Tuple{<:X, <:Y})
+    xbnds, ybnds = DD.intervalbounds(dims)
     dcrs = crs(dims)
     if convert(CoordSys, dcrs) == CoordSys("Earth Projection 1, 104") # check if need to reproject
         areas = [_area_from_coords(
@@ -80,6 +79,6 @@ function cellsize(dims::DimTuple)
     return Raster(areas, dims)
 end
 
-function cellsize(x::Union{AbstractRaster, AbstractRasterStack})
+function cellsize(x::Union{<:AbstractRaster, <:AbstractRasterStack, <:RA.DimTuple})
     cellsize(dims(x, (X, Y)))
 end

--- a/ext/RastersArchGDALExt/cellsize.jl
+++ b/ext/RastersArchGDALExt/cellsize.jl
@@ -50,7 +50,8 @@ end
 
 function cellsize(dims::Tuple{X, Y})
     xbnds, ybnds = DimensionalData.intervalbounds(dims)
-    dcrs = isnothing(crs(dims[2])) ? crs(dims[2]) : crs(dims[1])
+    # take CRS from Y if it has crs, else from X
+    dcrs = !isnothing(crs(dims[2])) ? crs(dims[2]) : crs(dims[1])
     if convert(CoordSys, dcrs) == CoordSys("Earth Projection 1, 104") # check if need to reproject
         areas = [_area_from_coords(
             GI.LinearRing([

--- a/ext/RastersArchGDALExt/cellsize.jl
+++ b/ext/RastersArchGDALExt/cellsize.jl
@@ -50,7 +50,8 @@ end
 
 function cellsize(dims::Tuple{X, Y})
     xbnds, ybnds = DimensionalData.intervalbounds(dims)
-    if convert(CoordSys, crs(dims)) == CoordSys("Earth Projection 1, 104") # check if need to reproject
+    dcrs = isnothing(crs(dims[2])) ? crs(dims[2]) : crs(dims[1])
+    if convert(CoordSys, dcrs) == CoordSys("Earth Projection 1, 104") # check if need to reproject
         areas = [_area_from_coords(
             GI.LinearRing([
                 (xb[1], yb[1]), 
@@ -61,7 +62,7 @@ function cellsize(dims::Tuple{X, Y})
             ]))
             for xb in xbnds, yb in ybnds]
     else 
-        areas = ArchGDAL.crs2transform(crs(dims), EPSG(4326)) do transform
+        areas = ArchGDAL.crs2transform(dcrs, EPSG(4326)) do transform
             [_area_from_coords(
                 transform,         
                 GI.LinearRing([

--- a/ext/RastersArchGDALExt/cellsize.jl
+++ b/ext/RastersArchGDALExt/cellsize.jl
@@ -48,10 +48,10 @@ function _area_from_coords(transform::ArchGDAL.CoordTransform, ::GI.LinearRingTr
     return _area_from_rads(GI.LinearRing(points))
 end
 
-function cellsize(dims::Tuple{X, Y})
+function cellsize(dims::DimTuple)
     xbnds, ybnds = DimensionalData.intervalbounds(dims)
     # take CRS from Y if it has crs, else from X
-    dcrs = !isnothing(crs(dims[2])) ? crs(dims[2]) : crs(dims[1])
+    dcrs = crs(dims)
     if convert(CoordSys, dcrs) == CoordSys("Earth Projection 1, 104") # check if need to reproject
         areas = [_area_from_coords(
             GI.LinearRing([

--- a/ext/RastersArchGDALExt/cellsize.jl
+++ b/ext/RastersArchGDALExt/cellsize.jl
@@ -79,6 +79,6 @@ function cellsize(dims::Tuple{X, Y})
     return Raster(areas, dims)
 end
 
-function cellsize(x::Raster)
+function cellsize(x::Union{AbstractRaster, AbstractRasterStack})
     cellsize(dims(x, (X, Y)))
 end

--- a/src/crs.jl
+++ b/src/crs.jl
@@ -8,7 +8,7 @@ For [`Mapped`](@ref) lookup this may be `nothing` as there may be no projected
 coordinate reference system at all.
 See [`setcrs`](@ref) to set it manually.
 """
-function GeoInterface.crs(obj::Union{<:AbstractRaster,<:AbstractRasterStack,<:AbstractRasterSeries})
+function GeoInterface.crs(obj::Union{<:AbstractRaster,<:AbstractRasterStack,<:AbstractRasterSeries, <:DimTuple})
     if hasdim(obj, Y)
         crs(dims(obj, Y))
     elseif hasdim(obj, X)

--- a/test/array.jl
+++ b/test/array.jl
@@ -37,7 +37,7 @@ end
     mappedcrs(ga1) == nothing
     gapr = setcrs(ga1, EPSG(4326))
     gampr = setmappedcrs(gapr, EPSG(4326))
-    @test crs(gapr) == crs(gapr[X(1)]) == EPSG(4326)
+    @test crs(gapr) == crs(gapr[X(1)]) == crs(dims(gapr)) == EPSG(4326)
     @test mappedcrs(gampr) == mappedcrs(gampr[X(1)]) == EPSG(4326)
 end
 

--- a/test/cellsize.jl
+++ b/test/cellsize.jl
@@ -10,8 +10,11 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
     dimz_25832 = X(Projected(0.0:100:10000.0; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(100), crs=EPSG(25832))),
        Y(Projected(0.0:100:10000.0; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(100), crs=EPSG(25832)))
 
+   ras = ones(dimz)
+
     cs = cellsize(dimz)
     cs2 = cellsize(dimz_25832)
+    cs_ras = cellsize(ras)
 
     # Check the output is a raster 
     @test cs isa Raster
@@ -21,5 +24,6 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
     # Test all areas are about 0.01 km2
     @test maximum(cs2) ≈ 0.01 rtol = 0.01
     @test minimum(cs2) ≈ 0.01 rtol = 0.01
+    @test cs == cs_ras
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ end
 @time @safetestset "reproject" begin include("reproject.jl") end
 @time @safetestset "warp" begin include("warp.jl") end
 @time @safetestset "resample" begin include("resample.jl") end
+@time @safetestset "cellsize" begin include("cellsize.jl") end
 
 # CommondataModel sources
 @time @safetestset "ncdatasets" begin include("sources/ncdatasets.jl") end


### PR DESCRIPTION
The cellsize function broke recently after a breaking change that caused `crs` to always return `nothing` for `Tuple`s.

This wasn't noticed because cellsize wasn't actually added to runtests.jl.

Maybe we want to consider also defining `crs` such that `crs(myraster)` and `crs(dims(myraster))` return the same thing. Unfortunately `dims(myraster) == NTuple` returns `false` so I'm not sure how to define in a way that is generic and specific to all Tuples of `Dimension`.