### PR TITLE
missingmask of all layers in rasterstack

### DIFF
--- a/src/methods/mask.jl
+++ b/src/methods/mask.jl
@@ -322,19 +322,6 @@ savefig("docs/build/missingmask_example.png"); nothing
 
 $EXPERIMENTAL
 """
-function missingmask_multilayer(layers::Union{<:AbstractRasterStack, <:AbstractRasterSeries}, to; kw...)
-    dest = _init_bools(to, Array{Union{Missing,Bool}}, layers; kw..., missingval=missing)
-    dest .= true
-    map(layers) do layer
-        missingval=_missingval_or_missing(layer)
-
-        broadcast_dims!(dest, dest, layer) do d, x
-            isequal(d, missing) || isequal(x, missingval) ? missing : true
-        end
-   end
-   return dest
-end
-
 function missingmask(stack::AbstractRasterStack; alllayers = true, to = dims(stack), kw...) 
     if alllayers
         missingmask_multilayer(stack, to; kw...)
@@ -371,4 +358,17 @@ function missingmask!(dest::AbstractRaster, geom; kw...)
     B = boolmask!(dest, geom; kw...)
     dest .= (b -> b ? true : missing).(B)
     return dest
+end
+
+function _missingmask_multilayer(layers::Union{<:AbstractRasterStack, <:AbstractRasterSeries}, to; kw...)
+    dest = _init_bools(to, Array{Union{Missing,Bool}}, layers; kw..., missingval=missing)
+    dest .= true
+    map(layers) do layer
+        missingval=_missingval_or_missing(layer)
+
+        broadcast_dims!(dest, dest, layer) do d, x
+            isequal(d, missing) || isequal(x, missingval) ? missing : true
+        end
+   end
+   return dest
 end

--- a/src/methods/mask.jl
+++ b/src/methods/mask.jl
@@ -324,7 +324,7 @@ $EXPERIMENTAL
 """
 function missingmask(stack::AbstractRasterStack; alllayers = true, to = dims(stack), kw...) 
     if alllayers
-        missingmask_multilayer(stack, to; kw...)
+        _missingmask_multilayer(stack, to; kw...)
     else
         missingmask(first(stack); kw...)
     end
@@ -332,7 +332,7 @@ end
 
 function missingmask(series::AbstractRasterSeries; alllayers = true, to = first(stack), kw...)
     if alllayers
-        missingmask_multilayer(series, to; kw...)
+        _missingmask_multilayer(series, to; kw...)
     else
         missingmask(first(series); kw...)
     end

--- a/src/methods/mask.jl
+++ b/src/methods/mask.jl
@@ -330,7 +330,7 @@ function missingmask(stack::AbstractRasterStack; alllayers = true, to = dims(sta
     end
 end
 
-function missingmask(series::AbstractRasterSeries; alllayers = true, to = first(stack), kw...)
+function missingmask(series::AbstractRasterSeries; alllayers = true, to = first(series), kw...)
     if alllayers
         _missingmask_multilayer(series, to; kw...)
     else

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -90,7 +90,8 @@ end
     @test all(missingmask(ga99) .=== [missing true; true missing])
     @test all(missingmask(gaNaN) .=== [missing true; true missing])
     @test all(missingmask(st[(:b, :a)], alllayers = true) .=== [missing true; true missing])
-    @test all(missingmask(st[(:b, :a)], alllayers = false) .=== [true true; true missing])    @test dims(missingmask(ga)) == dims(ga)
+    @test all(missingmask(st[(:b, :a)], alllayers = false) .=== [true true; true missing])    
+    @test dims(missingmask(ga)) == dims(ga)
     @test missingmask(polygon; res=1.0) == fill!(Raster{Union{Missing,Bool}}(undef, X(Projected(-20:1.0:-1.0; crs=nothing)), Y(Projected(10.0:1.0:29.0; crs=nothing))), true)
     x = missingmask([polygon, polygon]; collapse=false, res=1.0)
     @test eltype(x) == Union{Bool,Missing}

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -89,7 +89,8 @@ end
     @test all(missingmask(ga) .=== [missing true; true missing])
     @test all(missingmask(ga99) .=== [missing true; true missing])
     @test all(missingmask(gaNaN) .=== [missing true; true missing])
-    @test dims(missingmask(ga)) == dims(ga)
+    @test all(missingmask(st[(:b, :a)], alllayers = true) .=== [missing true; true missing])
+    @test all(missingmask(st[(:b, :a)], alllayers = false) .=== [true true; true missing])    @test dims(missingmask(ga)) == dims(ga)
     @test missingmask(polygon; res=1.0) == fill!(Raster{Union{Missing,Bool}}(undef, X(Projected(-20:1.0:-1.0; crs=nothing)), Y(Projected(10.0:1.0:29.0; crs=nothing))), true)
     x = missingmask([polygon, polygon]; collapse=false, res=1.0)
     @test eltype(x) == Union{Bool,Missing}

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -9,6 +9,8 @@ A = [missing 7.0f0; 2.0f0 missing]
 B = [1.0 0.4; 2.0 missing]
 ga = Raster(A, (X(1.0:1:2.0), Y(1.0:1:2.0)); missingval=missing) 
 st = RasterStack((a=A, b=B), (X, Y); missingval=(a=missing,b=missing))
+st2 = RasterStack((a=A[1,:], b=B), (X, Y); missingval=(a=missing,b=missing))
+se = RasterSeries([ga, ga], Rasters.Band(1:2))
 
 pointvec = [(-20.0, 30.0),
             (-20.0, 10.0),
@@ -89,9 +91,14 @@ end
     @test all(missingmask(ga) .=== [missing true; true missing])
     @test all(missingmask(ga99) .=== [missing true; true missing])
     @test all(missingmask(gaNaN) .=== [missing true; true missing])
+    @test dims(missingmask(ga)) == dims(ga)
     @test all(missingmask(st[(:b, :a)], alllayers = true) .=== [missing true; true missing])
     @test all(missingmask(st[(:b, :a)], alllayers = false) .=== [true true; true missing])    
-    @test dims(missingmask(ga)) == dims(ga)
+    mm_st2 = missingmask(st2)
+    @test dims(mm_st2) == dims(st2)
+    @test all(missingmask(st[(:b, :a)], alllayers = false) .=== [missing missing; true missing])    
+    @test all(missingmask(st2, alllayers = false) .=== [missing; true])    
+    @test all(missingmask(se) .=== missingmask(ga))
     @test missingmask(polygon; res=1.0) == fill!(Raster{Union{Missing,Bool}}(undef, X(Projected(-20:1.0:-1.0; crs=nothing)), Y(Projected(10.0:1.0:29.0; crs=nothing))), true)
     x = missingmask([polygon, polygon]; collapse=false, res=1.0)
     @test eltype(x) == Union{Bool,Missing}

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -96,7 +96,7 @@ end
     @test all(missingmask(st[(:b, :a)], alllayers = false) .=== [true true; true missing])    
     mm_st2 = missingmask(st2)
     @test dims(mm_st2) == dims(st2)
-    @test all(missingmask(st[(:b, :a)], alllayers = false) .=== [missing missing; true missing])    
+    @test all(mm_st2 .=== [missing missing; true missing])    
     @test all(missingmask(st2, alllayers = false) .=== [missing; true])    
     @test all(missingmask(se) .=== missingmask(ga))
     @test missingmask(polygon; res=1.0) == fill!(Raster{Union{Missing,Bool}}(undef, X(Projected(-20:1.0:-1.0; crs=nothing)), Y(Projected(10.0:1.0:29.0; crs=nothing))), true)


### PR DESCRIPTION
Changes the default behaviour of `missingmask` when applied on a RasterStack or RasterSeries, so the mask covers all layers.

It's probably possible to reduce the memory use of this operation by using missingmask!, but I can't really see how to guarantee that that works when not all dimensions are shared.

The dispatch on RasterSeries might run into errors if the dimensions are not shared between the layers, so maybe we don't want it? 