### PR TITLE
keep the name of a Raster when resampling

### DIFF
--- a/ext/RastersArchGDALExt/warp.jl
+++ b/ext/RastersArchGDALExt/warp.jl
@@ -26,7 +26,7 @@ function _warp(A::AbstractRaster, flags::Dict; filename=nothing, suffix="", kw..
         rds = Raster(dataset)
         AG.gdalwarp([dataset], flagvect; warp_kw...) do warped
             # Read the raster lazily, dropping Band if there is none in `A`
-            raster = Raster(warped; lazy=true, dropband=!hasdim(A, Band()))
+            raster = Raster(warped; lazy=true, dropband=!hasdim(A, Band()), name = name(A))
             # Either read the MEM dataset to an Array, or keep a filename base raster lazy
             return isnothing(filename) ? read(raster) : raster
         end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -22,7 +22,7 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
     end
 
     # Resample cea.tif using resample
-    cea = Raster(raster_path; missingval=0x00)
+    cea = Raster(raster_path; missingval=0x00, name = :cea)
     raster_output = resample(cea; res=output_res, crs=output_crs, method)
     disk_output = resample(cea; res=output_res, crs=output_crs, method, filename="resample.tif")
 
@@ -38,6 +38,7 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
         abs(step(dims(raster_output, X))) ≈ 
         abs(step(dims(disk_output, X))) ≈ 
         abs(step(dims(permuted_output, X))) ≈ output_res
+    @test name(cea) == name(raster_output)
 
     rm("resample.tif")
 


### PR DESCRIPTION
propogate a `Raster` name to a new raster created by `resample`.