### PR TITLE
fix reading a lazy rasterstack

### DIFF
--- a/src/stack.jl
+++ b/src/stack.jl
@@ -29,7 +29,7 @@ subset without loading the whole array.
 abstract type AbstractRasterStack{L} <: AbstractDimStack{L} end
 
 missingval(stack::AbstractRasterStack) = getfield(stack, :missingval)
-filename(stack::AbstractRasterStack) = filename(parent(stack))
+filename(stack::AbstractRasterStack) = map(s -> filename(s), stack)
 missingval(s::AbstractRasterStack, key::Symbol) = _singlemissingval(missingval(s), key)
 
 isdisk(st::AbstractRasterStack) = isdisk(layers(st, 1))

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -434,13 +434,13 @@ function Base.open(f::Function, st::AbstractRasterStack{<:NamedTuple}; kw...)
 end
 
 # Open all layers through nested closures, applying `f` to the rebuilt open stack
-_open_layers(f, st) = _open_layers(f, st, DD.layers(f), NamedTuple())
+_open_layers(f, st) = _open_layers(f, st, DD.layers(st), NamedTuple())
 function _open_layers(f, st, unopened::NamedTuple{K}, opened::NamedTuple) where K
     open(first(unopened)) do open_layer
-        _open_layers(f, st, Base.tail(unopened), merge(opened, NamedTuple{(first(K))}(open_layer)))
+        _open_layers(f, st, Base.tail(unopened), merge(opened, NamedTuple{(first(K),)}((open_layer,))))
     end
 end
-function _open_layers(f, st, unopened::NamedTuple{()}, opened)
+function _open_layers(f, st, unopened::NamedTuple{()}, opened::NamedTuple)
     f(rebuild(st; data=opened))
 end
 

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -548,7 +548,7 @@ end
         gdalstack_lazy = RasterStack((a=gdalpath, b=gdalpath); lazy=true)
         @test Rasters.isdisk(gdalstack_lazy.a)
         @test Rasters.isdisk(gdalstack_lazy.b)
-        gdalstack_read = read(lazygdalstack)
+        gdalstack_read = read(gdalstack_lazy)
         read!(gdalstack_lazy, gdalstack_read)
         gdalstack_eager = RasterStack((a=gdalpath, b=gdalpath); lazy=false)
         @test !Rasters.isdisk(gdalstack_eager.a)

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -548,9 +548,14 @@ end
         gdalstack_lazy = RasterStack((a=gdalpath, b=gdalpath); lazy=true)
         @test Rasters.isdisk(gdalstack_lazy.a)
         @test Rasters.isdisk(gdalstack_lazy.b)
+        gdalstack_read = read(lazygdalstack)
+        read!(gdalstack_lazy, gdalstack_read)
         gdalstack_eager = RasterStack((a=gdalpath, b=gdalpath); lazy=false)
         @test !Rasters.isdisk(gdalstack_eager.a)
         @test !Rasters.isdisk(gdalstack_eager.b)
+        gdalstack_read == gdalstack_eager
+        @test Rasters.filename(gdalstack_lazy) == (a=gdalpath, b=gdalpath)
+        @test Rasters.filename(gdalstack_read) == (a=nothing, b=nothing)
     end
 
     @testset "dropband" begin


### PR DESCRIPTION
fixes bugs in _open_layers, so `read(::RasterStack)` no longer errors.

Also fixes `filename(::RasterStack)` so it returns a `NamedTuple` of file names, rather than throwing an error.

 I added some tests for both changes.