### PR TITLE
extract over rows if rows are geometries

### DIFF
--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -64,7 +64,7 @@ function extract(x::RasterStackOrArray, data;
         NamedTuple{keys}
     end
     names = NamedTuple{names}(names)
-    if Tables.istable(data) && !(data isa AbstractVector{<:GeoInterface.NamedTuplePoint})
+    if !(data isa AbstractVector{<:GeoInterface.NamedTuplePoint}) && Tables.istable(data)
         geomcolnames = GI.geometrycolumns(data)
         if isnothing(geomcolnames) || !in(first(geomcolnames), Tables.columnnames(Tables.columns(data)))
             throw(ArgumentError("No `:geometry` column and `GeoInterface.geometrycolums(::$(typeof(data)))` does not define alternate columns"))

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -66,9 +66,17 @@ function extract(x::RasterStackOrArray, data;
     names = NamedTuple{names}(names)
     if Tables.istable(data)
         geomcolnames = GI.geometrycolumns(data)
-        isnothing(geomcolnames) && throw(ArgumentError("No `:geometry` column and `GeoInterface.geometrycolums(::$(typeof(data)))` does not define alternate columns"))
-        geometries = Tables.getcolumn(Tables.columns(data), first(geomcolnames))
-        _extract(T, x, geometries; dims, names, kw...)
+        if isnothing(geomcolnames)
+            rows = Tables.rows(data)
+            if GI.geomtrait(first(rows)) !== nothing
+                _extract(T, x, rows; dims, names, kw...)
+            else
+                throw(ArgumentError("No `:geometry` column and `GeoInterface.geometrycolums(::$(typeof(data)))` does not define alternate columns"))
+            end
+        else
+            geometries = Tables.getcolumn(Tables.columns(data), first(geomcolnames))
+            _extract(T, x, geometries; dims, names, kw...)
+        end
     else
         _extract(T, x, data; dims, names, kw...)
     end

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -66,10 +66,9 @@ function extract(x::RasterStackOrArray, data;
     names = NamedTuple{names}(names)
     if Tables.istable(data)
         geomcolnames = GI.geometrycolumns(data)
-        if isnothing(geomcolnames)
-            rows = Tables.rows(data)
-            if GI.geomtrait(first(rows)) !== nothing
-                _extract(T, x, rows; dims, names, kw...)
+        if isnothing(geomcolnames) || !(first(geomcolnames) in Tables.columnnames(data))
+            if GI.geomtrait(NamedTuple(first(Tables.rows(data)))) !== nothing
+                _extract(T, x, Tables.rowtable(data); dims, names, kw...)
             else
                 throw(ArgumentError("No `:geometry` column and `GeoInterface.geometrycolums(::$(typeof(data)))` does not define alternate columns"))
             end

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -64,9 +64,11 @@ function extract(x::RasterStackOrArray, data;
         NamedTuple{keys}
     end
     names = NamedTuple{names}(names)
-    if Tables.istable(data) && data !<: AbstractVector{<:GeoInterface.NamedTuplePoint}
+    if Tables.istable(data) && !(data isa AbstractVector{<:GeoInterface.NamedTuplePoint})
         geomcolnames = GI.geometrycolumns(data)
-        isnothing(geomcolnames) && throw(ArgumentError("No `:geometry` column and `GeoInterface.geometrycolums(::$(typeof(data)))` does not define alternate columns"))
+        if isnothing(geomcolnames) || !in(first(geomcolnames), Tables.columnnames(Tables.columns(data)))
+            throw(ArgumentError("No `:geometry` column and `GeoInterface.geometrycolums(::$(typeof(data)))` does not define alternate columns"))
+        end
         geometries = Tables.getcolumn(Tables.columns(data), first(geomcolnames))
         _extract(T, x, geometries; dims, names, kw...)
      else

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -95,11 +95,11 @@ function _extract(T, A::RasterStackOrArray, ::Nothing, geoms::AbstractArray; nam
     # TODO this will fail with mixed point/geom vectors
     if trait1 isa GI.PointTrait
         rows = (_extract_point(T, A, g; names, kw...) for g in geoms)
-        return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A))) : collect(rows)
+        return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A), names)) : collect(rows)
     else
         # This will be a list of vectors, we need to flatten it into one
         rows = Iterators.flatten(_extract(T, A, g; names, skipmissing, kw...) for g in geoms)
-        return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A))) : collect(rows)
+        return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A), names)) : collect(rows)
     end
 end
 function _extract(T, A::RasterStackOrArray, ::GI.AbstractFeatureTrait, feature; kw...)
@@ -111,7 +111,7 @@ function _extract(T, A::RasterStackOrArray, ::GI.FeatureCollectionTrait, fc; kw.
 end
 function _extract(T, A::RasterStackOrArray, ::GI.AbstractMultiPointTrait, geom; skipmissing=false, kw...)
     rows = (_extract_point(T, A, g; kw...) for g in GI.getpoint(geom))
-    return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A))) : collect(rows)
+    return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A), names)) : collect(rows)
 end
 function _extract(T, A::RasterStackOrArray, ::GI.AbstractGeometryTrait, geom;
     names, skipmissing=false, kw...
@@ -121,21 +121,21 @@ function _extract(T, A::RasterStackOrArray, ::GI.AbstractGeometryTrait, geom;
     # Add a row for each pixel that is `true` in the mask
     rows = (_maybe_add_fields(T, A, _prop_nt(A, I, names), I) for I in CartesianIndices(B) if B[I])
     # Maybe skip missing rows
-    return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A))) : collect(rows)
+    return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A), names)) : collect(rows)
 end
 _extract(T, x::RasterStackOrArray, trait::GI.PointTrait, point; kw...) =
     _extract_point(T, x, point; kw...)
 
-@inline _skip_missing_rows(rows, ::Missing) = Iterators.filter(row -> !any(ismissing, row), rows)
-@inline _skip_missing_rows(rows, missingval) = Iterators.filter(row -> !any(x -> ismissing(x) || x === missingval, row), rows)
-@inline function _skip_missing_rows(rows, missingval::NamedTuple{keys}) where keys
+@inline _skip_missing_rows(rows, ::Missing, names) = Iterators.filter(row -> !any(ismissing, row), rows)
+@inline _skip_missing_rows(rows, missingval, names) = Iterators.filter(row -> !any(x -> ismissing(x) || x === missingval, row), rows)
+@inline function _skip_missing_rows(rows, missingval::NamedTuple, names::NamedTuple{K}) where K
     # first check if all fields are equal - if so just call with the first value
     if Base.allequal(missingval) == 1
-        return _skip_missing_rows(rows, first(missingval))
+        return _skip_missing_rows(rows, first(missingval), names)
     else
         Iterators.filter(rows) do row
             # rows may or may not contain a :geometry field, so map over keys instead
-            !any(key -> ismissing(row[key]) && row[key] === missingval[key], keys)
+            !any(key -> ismissing(row[key]) && row[key] === missingval[key], K)
         end
     end
 end

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -64,19 +64,12 @@ function extract(x::RasterStackOrArray, data;
         NamedTuple{keys}
     end
     names = NamedTuple{names}(names)
-    if Tables.istable(data)
+    if Tables.istable(data) && data !<: AbstractVector{<:GeoInterface.NamedTuplePoint}
         geomcolnames = GI.geometrycolumns(data)
-        if isnothing(geomcolnames) || !(first(geomcolnames) in Tables.columnnames(data))
-            if GI.geomtrait(NamedTuple(first(Tables.rows(data)))) !== nothing
-                _extract(T, x, Tables.rowtable(data); dims, names, kw...)
-            else
-                throw(ArgumentError("No `:geometry` column and `GeoInterface.geometrycolums(::$(typeof(data)))` does not define alternate columns"))
-            end
-        else
-            geometries = Tables.getcolumn(Tables.columns(data), first(geomcolnames))
-            _extract(T, x, geometries; dims, names, kw...)
-        end
-    else
+        isnothing(geomcolnames) && throw(ArgumentError("No `:geometry` column and `GeoInterface.geometrycolums(::$(typeof(data)))` does not define alternate columns"))
+        geometries = Tables.getcolumn(Tables.columns(data), first(geomcolnames))
+        _extract(T, x, geometries; dims, names, kw...)
+     else
         _extract(T, x, data; dims, names, kw...)
     end
 end

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -137,7 +137,7 @@ _extract(T, x::RasterStackOrArray, trait::GI.PointTrait, point; kw...) =
     else
         Iterators.filter(rows) do row
             # rows may or may not contain a :geometry field, so map over keys instead
-            !any(key -> ismissing(row[key]) && row[key] === missingval[key], K)
+            !any(key -> ismissing(row[key]) || row[key] === missingval[key], K)
         end
     end
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -319,12 +319,6 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
             (geometry = (Y = 0.3, X = 10.0), test = missing)
         ])
 
-        @test all(extract(rast, (Y=[0.1, 0.2, 0.3], X=[9.0, 10.0, 10.0])) .=== [
-            (geometry = (Y = 0.1, X = 9.0), test = 1)
-            (geometry = (Y = 0.2, X = 10.0), test = 4)
-            (geometry = (Y = 0.3, X = 10.0), test = missing)
-        ])
-
         # Vector points
         @test all(extract(rast, [[9.0, 0.1], [10.0, 0.2]]) .== [
             (geometry = [9.0, 0.1], test = 1)
@@ -421,7 +415,7 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
         @test_throws ArgumentError extract(rast, (foo = zeros(4),))
     end
 
-    @testset "from stack" begin
+     @testset "from stack" begin
         @test all(extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]) .=== [
             (geometry = missing, test = missing, test2 = missing)
             (geometry = (9.0, 0.1), test = 1, test2 = 5)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -312,9 +312,8 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
             (index = (1, 1), test = 1,)
             (index = (1, 2), test = 2,)
         ])
-        # NamedTuple (reversed) points
-        @test all(extract(rast, [missing, (Y=0.1, X=9.0), (Y=0.2, X=10.0), (Y=0.3, X=10.0)]) .=== [
-            (geometry = missing, test = missing)
+        # NamedTuple (reversed) points - tests a Table that iterates over points
+        @test all(extract(rast, [(Y=0.1, X=9.0), (Y=0.2, X=10.0), (Y=0.3, X=10.0)]) .=== [
             (geometry = (Y = 0.1, X = 9.0), test = 1)
             (geometry = (Y = 0.2, X = 10.0), test = 4)
             (geometry = (Y = 0.3, X = 10.0), test = missing)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -318,6 +318,13 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
             (geometry = (Y = 0.2, X = 10.0), test = 4)
             (geometry = (Y = 0.3, X = 10.0), test = missing)
         ])
+
+        @test all(extract(rast, (Y=[0.1, 0.2, 0.3], X=[9.0, 10.0, 10.0])) .=== [
+            (geometry = (Y = 0.1, X = 9.0), test = 1)
+            (geometry = (Y = 0.2, X = 10.0), test = 4)
+            (geometry = (Y = 0.3, X = 10.0), test = missing)
+        ])
+
         # Vector points
         @test all(extract(rast, [[9.0, 0.1], [10.0, 0.2]]) .== [
             (geometry = [9.0, 0.1], test = 1)
@@ -410,6 +417,8 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
             (index = (1, 1), test = 1,)
             (index = (1, 2), test = 2,)
         ]
+
+        @test_throws ArgumentError extract(rast, (foo = zeros(4),))
     end
 
     @testset "from stack" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -423,18 +423,15 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
             (geometry = (10.0, 0.3), test = missing, test2 = missing)
         ])
         @test extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true) == [
-            (geometry = (9.0, 0.1), test = 1, test2 = 5)
             (geometry = (10.0, 0.2), test = 4, test2 = 8)
         ]
         @test extract(st2, [missing, (2, 2), (2,1)]; skipmissing=true) == [
             (geometry = (2, 1), a = 7.0, b = 2.0)
         ]
         @test extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false) == [
-            (test = 1, test2 = 5)
             (test = 4, test2 = 8)
         ]
         @test extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; skipmissing=true, geometry=false, index=true) == [
-            (index = (1, 1), test = 1, test2 = 5)
             (index = (2, 2), test = 4, test2 = 8)
         ]
         # Subset with `names`
@@ -444,6 +441,14 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
             (geometry = (10.0, 0.2), test2 = 8)
             (geometry = (10.0, 0.3), test2 = missing)
         ])
+        # Subset with `names` and `skipmissing` with mixed missingvals
+        @test extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; names=(:test2,), skipmissing = true) == [
+            (geometry = (10.0, 0.2), test2 = 8)
+        ]
+        @test extract(st, [missing, (9.0, 0.1), (10.0, 0.2), (10.0, 0.3)]; names=(:test,), skipmissing = true) == [
+            (geometry = (9.0, 0.1), test = 1)
+            (geometry = (10.0, 0.2), test = 4)
+        ]
     end
 end
 


### PR DESCRIPTION
adds a check to extract such that if `Tables.rows(x)` iterates geometries (e.g. X-Y points), the points are extracted. Previously this would throw an error.