### PR TITLE
Faster geom extract

### DIFF
--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -128,9 +128,9 @@ function _extract(::Type{T}, A::RasterStackOrArray, t::GI.AbstractGeometryTrait,
         template = view(template, map(d -> rebuild(d, firstindex(d)), ods)) 
     end
     B = boolmask(geom; to=template, kw...)
-    offset = CartesianIndex(map(first, parentindices(template)))
+    offset = CartesianIndex(map(first, parentindices(parent(template))))
     # Add a row for each pixel that is `true` in the mask
-    rows = (_maybe_add_fields(T, A, _prop_nt(A, I + offset, names), I) for I in CartesianIndices(B) if B[I])
+    rows = (_maybe_add_fields(T, A, _prop_nt(A, I + offset, names), I + offset) for I in CartesianIndices(B) if B[I])
     # Maybe skip missing rows
     return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A))) : collect(rows)
 end

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -113,11 +113,12 @@ function _extract(T, A::RasterStackOrArray, ::GI.AbstractMultiPointTrait, geom; 
     rows = (_extract_point(T, A, g; kw...) for g in GI.getpoint(geom))
     return skipmissing ? collect(_skip_missing_rows(rows, _missingval_or_missing(A))) : collect(rows)
 end
-function _extract(T, A::RasterStackOrArray, ::GI.AbstractGeometryTrait, geom;
+function _extract(T, A::RasterStackOrArray, t::GI.AbstractGeometryTrait, geom;
     names, skipmissing=false, kw...
 )
     # Make a raster mask of the geometry
-    B = boolmask(geom; to=commondims(A, DEFAULT_POINT_ORDER), kw...)
+    template = commondims(view(A, Touches(GI.extent(geom))), DEFAULT_POINT_ORDER)
+    B = boolmask(geom; to=template, kw...)
     # Add a row for each pixel that is `true` in the mask
     rows = (_maybe_add_fields(T, A, _prop_nt(A, I, names), I) for I in CartesianIndices(B) if B[I])
     # Maybe skip missing rows

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -128,7 +128,7 @@ function _extract(::Type{T}, A::RasterStackOrArray, t::GI.AbstractGeometryTrait,
         template = view(template, map(d -> rebuild(d, firstindex(d)), ods)) 
     end
     B = boolmask(geom; to=template, kw...)
-    offset = CartesianIndex(map(first, parentindices(parent(template))))
+    offset = CartesianIndex(map(x -> first(x) - 1, parentindices(parent(template))))
     # Add a row for each pixel that is `true` in the mask
     rows = (_maybe_add_fields(T, A, _prop_nt(A, I + offset, names), I + offset) for I in CartesianIndices(B) if B[I])
     # Maybe skip missing rows

--- a/src/methods/mask.jl
+++ b/src/methods/mask.jl
@@ -285,11 +285,12 @@ function boolmask!(dest::AbstractRaster, src::AbstractRaster;
     end
 end
 function boolmask!(dest::AbstractRaster, geoms;
-    allocs=nothing, lock=nothing, progress=true, threaded=false, kw...
+    lock=nothing, 
+    progress=true, 
+    threaded=false, 
+    allocs=_burning_allocs(dest; threaded), 
+    kw...
 )
-    if isnothing(allocs)
-        allocs = _burning_allocs(dest; threaded)
-    end
     if hasdim(dest, :geometry)
         range = _geomindices(geoms)
         _run(range, threaded, progress, "Burning each geometry to a BitArray slice...") do i


### PR DESCRIPTION
Closes #637

A few simple changes that make line extract 3 order of magnitude faster:

- use a view of the geometry extent before masking
- type stability