### PR TITLE
collapse missingval when constructing rasterstack if possible

### DIFF
--- a/src/stack.jl
+++ b/src/stack.jl
@@ -230,6 +230,9 @@ function RasterStack(layers::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractRaster}}}
     layerdims=map(DD.basedims, layers)
     layermetadata=map(DD.metadata, layers)
     missingval=map(Rasters.missingval, layers)
+    if Base.allequal(missingval)
+        missingval = first(missingval)
+    end
     return RasterStack(
         data, dims, refdims, layerdims, metadata, layermetadata, missingval
     )

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -85,7 +85,7 @@ function DD.rebuild_from_arrays(
     layermetadata=map(DD.metadata, das),
     missingval=map(missingval, das),
 )
-    missingval = Base.allequal(missingval) ? first(missingval) : missingval
+    missingval = all(m -> m === first(missingval), missingval) ? first(missingval) : missingval
     if isnothing(dims)
         # invokelatest avoids compiling this for other paths
         Base.invokelatest() do
@@ -231,7 +231,8 @@ function RasterStack(layers::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractRaster}}}
     layerdims=map(DD.basedims, layers)
     layermetadata=map(DD.metadata, layers)
     missingval=map(Rasters.missingval, layers)
-    if Base.allequal(missingval)
+    @show missingval
+    if !ismissing(missingval) && all(m -> m === first(missingval), missingval)
         missingval = first(missingval)
     end
     return RasterStack(

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -40,6 +40,14 @@ setmappedcrs(x::AbstractRasterStack, mappedcrs) = set(x, setmappedcrs(dims(x), m
 
 _singlemissingval(mvs::NamedTuple, key) = mvs[key]
 _singlemissingval(mv, key) = mv
+function _maybe_collapse_missingval(mvs::NamedTuple)
+    mv1, mvs_rest = Iterators.peel(mvs)
+    for mv in mvs_rest
+        mv === mv1 || return mvs
+    end
+    return mv1
+end
+_maybe_collapse_missingval(mv) = mv
 
 # DimensionalData methods ######################################################
 
@@ -83,9 +91,8 @@ function DD.rebuild_from_arrays(
     dims=nothing,
     layerdims=map(DD.basedims, das),
     layermetadata=map(DD.metadata, das),
-    missingval=map(missingval, das),
+    missingval=_maybe_collapse_missingval(map(missingval, das)),
 )
-    missingval = all(m -> m === first(missingval), missingval) ? first(missingval) : missingval
     if isnothing(dims)
         # invokelatest avoids compiling this for other paths
         Base.invokelatest() do
@@ -231,10 +238,7 @@ function RasterStack(layers::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractRaster}}}
     layerdims=map(DD.basedims, layers)
     layermetadata=map(DD.metadata, layers)
     missingval=map(Rasters.missingval, layers)
-    @show missingval
-    if !ismissing(missingval) && all(m -> m === first(missingval), missingval)
-        missingval = first(missingval)
-    end
+    missingval = _maybe_collapse_missingval(missingval)
     return RasterStack(
         data, dims, refdims, layerdims, metadata, layermetadata, missingval
     )

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -85,6 +85,7 @@ function DD.rebuild_from_arrays(
     layermetadata=map(DD.metadata, das),
     missingval=map(missingval, das),
 )
+    missingval = Base.allequal(missingval) ? first(missingval) : missingval
     if isnothing(dims)
         # invokelatest avoids compiling this for other paths
         Base.invokelatest() do


### PR DESCRIPTION
Before this PR, a call to `RasterStack` will always return a stack where `missingval` is a `NamedTuple`, which looks kind of clunky if all rasters in a big stack have the same `missingval`.

This just checks if all `missingval`s are the same, and sets the missingval to just a value if that's the case.