### PR TITLE
stack replace_missing and bugfixes

### DIFF
--- a/ext/RastersArchGDALExt/gdal_source.jl
+++ b/ext/RastersArchGDALExt/gdal_source.jl
@@ -57,7 +57,7 @@ function Base.write(
     RA.check_can_write(filename, force)
     A1 = _maybe_correct_to_write(A, missingval)
     _create_with_driver(filename, dims(A1), eltype(A1), Rasters.missingval(A1); _block_template=A1, kw...) do dataset
-        verbose && _maybe_warn_south_up(A, verbose, "Writing South-up. Use `reverse(x; dims=Y)` first to write conventional North-up")
+        verbose && _maybe_warn_south_up(A, verbose, "Writing South-up. Use `reverse(myrast; dims=Y)` first to write conventional North-up")
         open(A1; write=true) do O
             AG.RasterDataset(dataset) .= parent(O)
         end
@@ -76,7 +76,7 @@ function RA.create(filename, ::GDALsource, T::Type, dims::DD.DimTuple;
     T = Missings.nonmissingtype(T)
     missingval = ismissing(missingval) ? RA._writeable_missing(T) : missingval
     _create_with_driver(filename, dims, T, missingval; kw...) do _
-        verbose && _maybe_warn_south_up(dims, verbose, "Creating a South-up raster. Use `reverse(x; dims=Y)` first to write conventional North-up")
+        verbose && _maybe_warn_south_up(dims, verbose, "Creating a South-up raster. Use `reverse(myrast; dims=Y)` first to write conventional North-up")
         nothing
     end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -339,7 +339,7 @@ function _fix_missingval(::Type{T}, missingval::M) where {T,M}
     if missingval isa T
         missingval
     elseif hasmethod(convert, Tuple{Type{T1},M}) && isreal(missingval) && 
-            missingval <= typemax(T1) && missingval >= typemin(T)
+            missingval <= typemax(T1) && missingval >= typemin(T1)
         if T1 <: Integer && !isinteger(missingval) 
             nothing
         else

--- a/src/array.jl
+++ b/src/array.jl
@@ -74,11 +74,6 @@ function DD.rebuild(A::AbstractRaster;
     rebuild(A, data, dims, refdims, name, metadata, missingval)
 end
 
-function _fix_missingval(::Type{T}, x::X) where {T,X} 
-    promote_type(T, X) === T ? convert(T, x) : nothing
-end
-_fix_missingval(::Type{T}, mv::M) where {T,M<:T} = mv
-
 function DD.modify(f, A::AbstractRaster)
     # Have to avoid calling `open` on CFDiskArray
     newdata = if isdisk(A) && !(parent(A) isa CFDiskArray)

--- a/src/methods/shared_docstrings.jl
+++ b/src/methods/shared_docstrings.jl
@@ -95,3 +95,9 @@ const GROUP_KEYWORD = """
     A `String` or `Symbol` will select a single group. Pairs can also used to access groups
     at any nested depth, i.e `group=:group1 => :group2 => :group3`.
 """
+
+const REPLACE_MISSING_KEYWORD = """
+- `replace_missing`: replace `missingval` with `missing`. This is done lazily if `lazy=true`.
+    Note that currently for NetCDF and GRIB files `replace_missing` is always true. 
+    In future `replace_missing=false` will also work for these data sources.
+"""

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -314,14 +314,20 @@ end
 
 @testset "Grd stack" begin
     grdstack = RasterStack((a=grdpath, b=grdpath))
-    @time lazystack = RasterStack((a=grdpath, b=grdpath); lazy=true);
-    @time eagerstack = RasterStack((a=grdpath, b=grdpath); lazy=false);
 
     @testset "lazyness" begin
-        # Lazy is the default
+        # Eager is the default
         @test parent(grdstack[:a]) isa Array
+        @time lazystack = RasterStack((a=grdpath, b=grdpath); lazy=true);
+        @time eagerstack = RasterStack((a=grdpath, b=grdpath); lazy=false);
         @test parent(lazystack[:a]) isa FileArray
         @test parent(eagerstack[:a]) isa Array
+    end
+
+    @testset "replace_missing keyword" begin
+        st = RasterStack((a=grdpath, b=grdpath); replace_missing=true)
+        @test eltype(st) == @NamedTuple{a::Union{Missing,Float32},b::Union{Missing,Float32}}
+        @test missingval(st) === missing
     end
 
     @test length(layers(grdstack)) == 2

--- a/test/sources/rasterdatasources.jl
+++ b/test/sources/rasterdatasources.jl
@@ -19,8 +19,9 @@ using Rasters, RasterDataSources, Test, Dates, ArchGDAL, NCDatasets
     @test A isa Raster
     A[Y(Between(-10, -45)), X(Between(110, 160))]
     st = RasterStack(WorldClim{Climate}, (:prec, :tmax); month=1)
-    st[:prec]
-    @test st isa RasterStack
+    @test st[:prec] == A
+    @test missingval(st) == (prec=-32768, tmax=-3.4f38)
+    @test st isa RasterStack{(:prec,:tmax),@NamedTuple{prec::Int16,tmax::Float32},2}
 end
 
 @testset "load WorldClim BioClim" begin


### PR DESCRIPTION
fixes some bugs with missing value conversion, and adds `replace_missing` keyword to stacks as it was missing from the earlier PR