### PR TITLE
match to-dims with resample

### DIFF
--- a/ext/RastersArchGDALExt/resample.jl
+++ b/ext/RastersArchGDALExt/resample.jl
@@ -108,8 +108,3 @@ function resample(A::RasterStackOrArray;
 end
 
 _size_and_res_error() = throw(ArgumentError("Include only `size` or `res` keywords, not both"))
-
-resampled
-
-ds = (Y(1:10), (X(1:10)))
-commondims(ds, (X, Y))

--- a/ext/RastersArchGDALExt/resample.jl
+++ b/ext/RastersArchGDALExt/resample.jl
@@ -100,10 +100,16 @@ function resample(A::RasterStackOrArray;
 
     # if only to is provided and it has dims, make sure dims are the exact same 
     if onlyto
-        resampled = rebuild(resampled; dims = dims(to))
+        newdims = (commondims(to, XDim, YDim)..., otherdims(A, (XDim, YDim))...)
+        resampled = rebuild(resampled; dims =newdims)
     end
 
     return resampled
 end
 
 _size_and_res_error() = throw(ArgumentError("Include only `size` or `res` keywords, not both"))
+
+resampled
+
+ds = (Y(1:10), (X(1:10)))
+commondims(ds, (X, Y))

--- a/ext/RastersArchGDALExt/resample.jl
+++ b/ext/RastersArchGDALExt/resample.jl
@@ -17,6 +17,9 @@ function resample(A::RasterStackOrArray;
     # Method
     flags[:r] = method
 
+    # check if only to has been provided before overwriting arguments
+    onlyto = !isnothing(to) && !isnothing(dims(to)) && !(to isa Extents.Extent) && isnothing(res) && isnothing(size) && isnothing(crs)
+
     # Extent
     if to isa Extents.Extent || isnothing(to) || isnothing(dims(to))
         to = isnothing(to) || to isa Extents.Extent ? to : GeoInterface.extent(to)
@@ -91,12 +94,12 @@ function resample(A::RasterStackOrArray;
     resampled = warp(A, flags; kw...)
 
     # Return crs to the original type, from GDAL it will always be WellKnownText
-    if isnothing(crs)
-        resampled = setcrs(resampled, Rasters.crs(A))
+    if !isnothing(crs)
+        resampled = setcrs(resampled, crs)
     end
 
     # if only to is provided and it has dims, make sure dims are the exact same 
-    if isnothing(res) && isnothing(size) && !isnothing(dims(to))
+    if onlyto
         resampled = rebuild(resampled; dims = dims(to))
     end
 

--- a/ext/RastersArchGDALExt/resample.jl
+++ b/ext/RastersArchGDALExt/resample.jl
@@ -26,11 +26,13 @@ function resample(A::RasterStackOrArray;
             flags[:te] = [xmin, ymin, xmax, ymax]
         end
     else
-        all(hasdim(to, (XDim, YDim))) || throw(ArgumentError("`to` must have both `XDim` and `YDim` dimensions to resize with GDAL"))
+        all(hasdim(to, (XDim, YDim))) || throw(ArgumentError("`to` must have both `XDim` and `YDim` dimensions to resample with GDAL"))
 
         # Set res from `to` if it was not already set
         if isnothing(res) && isnothing(size)
-            ysize, xsize = length.(dims(to, (XDim, YDim)))
+            todims = dims(to, (XDim, YDim))
+            all(isregular, todims) || throw(ArgumentError("`to` has irregular dimensions. Provide regular dimensions, or explicitly provide `res` or `size`."))
+            ysize, xsize = length.(todims)
             flags[:ts] = [ysize, xsize]
         end
         (xmin, xmax), (ymin, ymax) = bounds(to, (XDim, YDim))
@@ -97,7 +99,7 @@ function resample(A::RasterStackOrArray;
     if isnothing(res) && isnothing(size) && !isnothing(dims(to))
         resampled = rebuild(resampled; dims = dims(to))
     end
-    
+
     return resampled
 end
 

--- a/ext/RastersArchGDALExt/resample.jl
+++ b/ext/RastersArchGDALExt/resample.jl
@@ -34,7 +34,7 @@ function resample(A::RasterStackOrArray;
         # Set res from `to` if it was not already set
         if isnothing(res) && isnothing(size)
             todims = dims(to, (XDim, YDim))
-            all(isregular, todims) || throw(ArgumentError("`to` has irregular dimensions. Provide regular dimensions, or explicitly provide `res` or `size`."))
+            isregular(todims) || throw(ArgumentError("`to` has irregular dimensions. Provide regular dimensions, or explicitly provide `res` or `size`."))
             ysize, xsize = length.(todims)
             flags[:ts] = [ysize, xsize]
         end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -1,6 +1,8 @@
 using Rasters, ArchGDAL, GeoInterface, Extents
 using Test
 using Rasters.Lookups
+import DimensionalData: @dim, YDim
+@dim Lat YDim "Lat"
 
 include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
 
@@ -159,8 +161,6 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
     end
 
     @testset "dimensions matcha after resampling with only `to`" begin
-        import DimensionalData: @dim, YDim
-        @dim Lat YDim "Lat"
         # some weird dimensions
         to = (
             Lat(Projected(1:10, span = Regular(1 + eps()), crs = nothing, order = ForwardOrdered(), sampling = Intervals(Center()))),
@@ -173,7 +173,7 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
         # test with 3d
         resampled_3D = resample(cat(cea, cea; dims = Z(1:2)); to)
         @test length(dims(resampled_3D)) == 3
-        @test commondims(resampled_3D, (Rasters.XDim, Rasters.YDim)) == to
+        @test dims(resampled_3D, (1,2)) == to
         @test dims(resampled_3D, Z) == Z(1:2)
     end
 end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -159,12 +159,13 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
     end
 
     @testset "dimensions matcha after resampling with only `to`" begin
+        import DimensionalData: @dim, YDim
         @dim Lat YDim "Lat"
-        # some nonsensical dimensions that maybe should be illegal
+        # some weird dimensions
         to = (
-            Lat(Projected(1:10, span = Regular(2), crs = nothing, order = ForwardOrdered(), sampling = Intervals(Center()))),
-            X(Sampled([1,2,3], span = Regular(1), order = ReverseOrdered(), sampling = Intervals(Start())))
-            )
+            Lat(Projected(1:10, span = Regular(1 + eps()), crs = nothing, order = ForwardOrdered(), sampling = Intervals(Center()))),
+            X(Sampled([1,2,3], span = Regular(1), order = ForwardOrdered(), sampling = Intervals(Start())))
+        )
 
         resampled = resample(cea; to)
         @test dims(resampled) == to

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -157,4 +157,15 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
             @test dims(resampled_res) == dims(resampled_size) == dims(raster)
         end
     end
+
+    @testset "dimensions matcha after resampling with only `to`" begin
+        # some nonsensical dimensions that maybe should be illegal
+        to = (
+            X(Projected(1:10, span = Regular(2), crs = nothing, order = ForwardOrdered(), sampling = Intervals(Center()))),
+            Y(Sampled([1,2,3], span = Regular(1), order = ReverseOrdered(), sampling = Intervals(Start())))
+            )
+
+        resampled = resample(cea; to)
+        @test dims(resampled) === to
+    end
 end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -159,13 +159,20 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
     end
 
     @testset "dimensions matcha after resampling with only `to`" begin
+        @dim Lat YDim "Lat"
         # some nonsensical dimensions that maybe should be illegal
         to = (
-            X(Projected(1:10, span = Regular(2), crs = nothing, order = ForwardOrdered(), sampling = Intervals(Center()))),
-            Y(Sampled([1,2,3], span = Regular(1), order = ReverseOrdered(), sampling = Intervals(Start())))
+            Lat(Projected(1:10, span = Regular(2), crs = nothing, order = ForwardOrdered(), sampling = Intervals(Center()))),
+            X(Sampled([1,2,3], span = Regular(1), order = ReverseOrdered(), sampling = Intervals(Start())))
             )
 
         resampled = resample(cea; to)
-        @test dims(resampled) === to
+        @test dims(resampled) == to
+
+        # test with 3d
+        resampled_3D = resample(cat(cea, cea; dims = Z(1:2)); to)
+        @test length(dims(resampled_3D)) == 3
+        @test commondims(resampled_3D, (Rasters.XDim, Rasters.YDim)) == to
+        @test dims(resampled_3D, Z) == Z(1:2)
     end
 end


### PR DESCRIPTION
This PR ensures that the `x` and `to` have the same dimensions after resampling, if only `to` is provided.

Using size rather than resolution as a fallback means floating point error does not affect the outcome.

If only `to` is provided, the dimensions of the resampled raster will be set exactly match the dimensions of `to`.