### PR TITLE
check crs (and sampling) in cellsize and reproject

### DIFF
--- a/ext/RastersArchGDALExt/RastersArchGDALExt.jl
+++ b/ext/RastersArchGDALExt/RastersArchGDALExt.jl
@@ -18,7 +18,8 @@ using Rasters.Lookups
 using Rasters.Dimensions
 using Rasters: GDALsource, AbstractProjected, RasterStackOrArray, FileArray, NoKW,
     RES_KEYWORD, SIZE_KEYWORD, CRS_KEYWORD, FILENAME_KEYWORD, SUFFIX_KEYWORD, EXPERIMENTAL,
-    GDAL_EMPTY_TRANSFORM, GDAL_TOPLEFT_X, GDAL_WE_RES, GDAL_ROT1, GDAL_TOPLEFT_Y, GDAL_ROT2, GDAL_NS_RES
+    GDAL_EMPTY_TRANSFORM, GDAL_TOPLEFT_X, GDAL_WE_RES, GDAL_ROT1, GDAL_TOPLEFT_Y, GDAL_ROT2, GDAL_NS_RES,
+    _no_crs_error
 
 import Rasters: reproject, resample, warp, cellsize, nokw
 

--- a/src/methods/reproject.jl
+++ b/src/methods/reproject.jl
@@ -27,6 +27,7 @@ reproject(target::GeoFormat, l::Lookup) = l
 reproject(target::GeoFormat, dim::Dimension) = rebuild(dim, reproject(target, lookup(dim)))
 function reproject(target::GeoFormat, l::AbstractProjected)
     source = crs(l)
+    isnothing(source) && _no_crs_error()
     newdata = reproject(source, target, l.dim, parent(l))
     newlookup = rebuild(l; data=newdata, crs=target)
     if _checkregular(newdata)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -197,6 +197,8 @@ _progress(args...; kw...) = ProgressMeter.Progress(args...; color=:blue, barlen=
 
 _size_and_res_error() = throw(ArgumentError("Both `size` and `res` keywords are passed, but only one can be used"))
 
+_no_crs_error() = throw(ArgumentError("The provided object does not have a CRS. Use `setcrs` to set one."))
+
 _type_missingval(::Type{T}) where T = typemin(T)
 _type_missingval(::Type{T}) where T<:Unsigned = typemax(T) 
 

--- a/test/cellsize.jl
+++ b/test/cellsize.jl
@@ -1,20 +1,19 @@
-using Rasters, Rasters.Lookups, ArchGDAL
+using Rasters, DimensionalData, Rasters.Lookups, ArchGDAL
 using Test
-
+using DimensionalData: @dim, YDim
 include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
 
 @testset "cellsize" begin
-    dimz = X(Projected(90.0:0.1:99.9; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(0.1), crs=EPSG(4326))),
-       Y(Projected(0.0:0.1:89.9; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(0.1), crs=EPSG(4326)))
+    x = X(Projected(90.0:0.1:99.9; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(0.1), crs=EPSG(4326)))
+    y = Y(Projected(0.0:0.1:89.9; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(0.1), crs=EPSG(4326)))
+    dimz = (x,y)
 
     dimz_25832 = X(Projected(0.0:100:10000.0; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(100), crs=EPSG(25832))),
        Y(Projected(0.0:100:10000.0; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(100), crs=EPSG(25832)))
-
-   ras = ones(dimz)
+    ras = ones(dimz)
 
     cs = cellsize(dimz)
     cs2 = cellsize(dimz_25832)
-    cs_ras = cellsize(ras)
 
     # Check the output is a raster 
     @test cs isa Raster
@@ -24,6 +23,23 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
     # Test all areas are about 0.01 km2
     @test maximum(cs2) ≈ 0.01 rtol = 0.01
     @test minimum(cs2) ≈ 0.01 rtol = 0.01
+    # test passing in a raster or dims gives the same result
+    cs_ras = cellsize(ras)
     @test cs == cs_ras
+
+    # test a YDim other than Y is handled correctly
+    @dim Lat YDim "latitude"
+    lat = Lat(Projected(0.0:0.1:89.9; sampling=Intervals(Start()), order = ForwardOrdered(), span = Regular(0.1), crs=EPSG(4326)))
+    cs_lat = cellsize((x, lat))
+    @test parent(cs_lat) == parent(cs)
+    @test dims(cs_lat) == (x, lat)
+
+    # test point sampling throws an error
+    pointsy = set(y, Points())
+    @test_throws ArgumentError cellsize((x, pointsy))
+
+    # test missing crs throws an error
+    nocrsdimz = setcrs(dimz, nothing)
+    @test_throws ArgumentError cellsize(nocrsdimz)
 
 end

--- a/test/reproject.jl
+++ b/test/reproject.jl
@@ -41,6 +41,10 @@ using Rasters: reproject, convertlookup
 
     @test_throws ArgumentError reproject(cea, EPSG(32618), Y(), [-3.658789324855012e6])
     @test_throws ArgumentError reproject(cea, EPSG(32618), X(), [-3.658789324855012e6])
+
+    # reproject with no crs errors
+    nocrsdims = setcrs((x,y), nothing)
+    @test_throws ArgumentError reproject(nocrsdims; crs=projcea)
 end
 
 @testset "convertlookup" begin


### PR DESCRIPTION
Adds checks to `reproject` and `cellsize`, so both error if an object without a CRS is passed, and `cellsize` additionally errors if an object with Points sampling is passed.