### PR TITLE
check memory use in coverage before allocating for a specified `scale`

### DIFF
--- a/test/rasterize.jl
+++ b/test/rasterize.jl
@@ -506,4 +506,8 @@ end
     @test all(mask(covsum; with=touchescount) .=== covsum)
     @test !all(mask(covunion; with=insidecount) .=== covunion)
     # TODO test coverage along all the lines is correct somehow
+    
+    @test_throws ArgumentError coverage(union, shphandle.shapes; threaded=false, res=1, scale=10000)
+    # Too slow and unreliable to test in CI, but it warns and uses one thread given 32gb of RAM: 
+    # coverage(union, shphandle.shapes; threaded=true, res=1, scale=1000)
 end


### PR DESCRIPTION
Its possible to crash julia currently when calling `coverage` by using a large `scale` value (like 10000 or just 1000 if your array is big enough).

This PR checks system memory before we allocate buffers and throws some helpful errors and warnings. 

If the problem comes from threaded, we switch to single threaded so save buffer memory, but warn when we do that.

Closes #661