### PR TITLE
Add .nc4 as NCDatasets extension

### DIFF
--- a/src/sources/sources.jl
+++ b/src/sources/sources.jl
@@ -28,7 +28,7 @@ const SOURCE2SYMBOL = Dict(map(reverse, collect(pairs(SYMBOL2SOURCE))))
 # File extensions. GDAL is the catch-all for everything else
 const SOURCE2EXT = Dict(
     GRDsource() => (".grd", ".gri"), 
-    NCDsource() => (".nc", ".h5",), 
+    NCDsource() => (".nc", ".nc4", ".h5",), 
     GRIBsource() => (".grib",), 
 )
 const SOURCE2PACKAGENAME = Dict(
@@ -41,6 +41,7 @@ const EXT2SOURCE = Dict(
     ".grd" => GRDsource(), 
     ".gri" => GRDsource(), 
     ".nc" => NCDsource(), 
+    ".nc4" => NCDsource(), 
     ".h5" => NCDsource(),
     ".grib" => GRIBsource(), 
 )


### PR DESCRIPTION
This PR makes files with `.nc4` extensions use `NCDatasets` as the default backend.

I'm working with some climate data files with `.nc4` extension ([more info here](https://www.earthdata.nasa.gov/esdis/esco/standards-and-practices/netcdf-4hdf5-file-format)).

Currently, I get this error message:
```Julia
julia> Raster(paths[1], lazy=true)
ERROR: `Rasters.jl` requires backends to be loaded externally as of version 0.8. Run `import ArchGDAL` to fix this error.
Stacktrace:
 [1] _open(f::Function, s::Rasters.GDALsource, filename::String; kw::@Kwargs{})
   @ Rasters ~/.julia/packages/Rasters/1JI3p/src/sources/sources.jl:81
 [2] _open(f::Function, s::Rasters.GDALsource, filename::String)
   @ Rasters ~/.julia/packages/Rasters/1JI3p/src/sources/sources.jl:79
 [3] _open(f::Function, filename::String; source::Rasters.GDALsource, kw::@Kwargs{})
   @ Rasters ~/.julia/packages/Rasters/1JI3p/src/sources/sources.jl:77
 [4] Raster(filename::String; source::Rasters.NoKW, kw::@Kwargs{lazy::Bool})
   @ Rasters ~/.julia/packages/Rasters/1JI3p/src/array.jl:292
 [5] top-level scope
   @ REPL[9]:1
```

Additionally, perhaps this error message could be made somewhat more useful? 

I tried to trace down where the error message comes from, but was not successful.
In any case, something like: 

> If you want to specify a different backend, set the keyword `source` to one of `:gdal`, `:netcdf`, `:grd`, or `:grib`. E.g. `Raster(file; source=:netcdf)`.

could be useful.