### PR TITLE
fix typos

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ using Rasters.LookupArrays, Rasters.Dimensions
 # Don't output huge svgs for Makie plots
 CairoMakie.activate!(type = "png")
 
-# Plots warnings are brWarn doctests. They dont warn the second time.
+# Plots warnings are brWarn doctests. They don't warn the second time.
 # Downloads also show op in doctests. So download everything first.
 function flush_info_and_warnings()
     # RasterStack(AWAP, (:tmin, :tmax); date=DateTime(2001, 1, 1))

--- a/ext/RastersArchGDALExt/gdal_source.jl
+++ b/ext/RastersArchGDALExt/gdal_source.jl
@@ -142,9 +142,9 @@ function RA._dims(raster::AG.RasterDataset, crs=nokw, mappedcrs=nokw)
     mappedcrs = mappedcrs isa NoKW ? nothing : mappedcrs
     xy_metadata = metadata(raster)
 
-    # Output Sampled index dims when the transformation is lat/lon alligned,
+    # Output Sampled index dims when the transformation is lat/lon aligned,
     # otherwise use Transformed index, with an affine map.
-    if _isalligned(gt)
+    if _isaligned(gt)
         # Get step sizes
         xstep = gt[GDAL_WE_RES]
         ystep = gt[GDAL_NS_RES] # Usually a negative number
@@ -433,7 +433,7 @@ function _process_options(driver::String, options::Dict;
             else
                 xchunksize == 1 || @warn "X and Y chunk size do not match. Columns are used and X size $xchunksize is ignored"
             end
-            # dont overwrite user specified values
+            # don't overwrite user specified values
             if !("BLOCKXSIZE" in keys(options_str))
                 options_str["BLOCKXSIZE"] = block_x
             end
@@ -469,7 +469,7 @@ function _process_options(driver::String, options::Dict;
     return options_vec
 end
 
-# Bands can have text names, but usually dont
+# Bands can have text names, but usually don't
 function _bandnames(rds::AG.RasterDataset, nbands=AG.nraster(rds))
     map(1:nbands) do b
         AG.getband(rds.ds, b) do band
@@ -553,7 +553,7 @@ function _set_dataset_properties!(dataset::AG.Dataset, dims::Tuple, missingval)
     return dataset
 end
 
-# Detect the driver string from the extention
+# Detect the driver string from the extension
 _extensiondriver(filename::Nothing) = "MEM"
 function _extensiondriver(filename::AbstractString)
     # TODO move this check to ArchGDAL
@@ -625,7 +625,7 @@ end
 RA.geotransform2affine(gt) = error(USING_COORDINATETRANSFORMATIONS_MESSAGE)
 RA.affine2geotransform(am) = error(USING_COORDINATETRANSFORMATIONS_MESSAGE)
 
-_isalligned(geotransform) = geotransform[GDAL_ROT1] == 0 && geotransform[GDAL_ROT2] == 0
+_isaligned(geotransform) = geotransform[GDAL_ROT1] == 0 && geotransform[GDAL_ROT2] == 0
 
 # precompilation
 # function _precompile(::Type{GDALsource})

--- a/src/array.jl
+++ b/src/array.jl
@@ -192,7 +192,7 @@ methods will _not_ load data from disk; they will be applied later, lazily.
 
 # Keywords
 
-- `name`: a `Symbol` name for the array, which will also retreive the, alphabetically first, 
+- `name`: a `Symbol` name for the array, which will also retrieve the, alphabetically first, 
     named layer if `Raster` is used on a multi-layered file like a NetCDF. 
     If instead `RasterStack` is used to read the multi-layered file, by default, all variables 
     will be added to the stack.

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -203,7 +203,7 @@ function dims2geotransform end
 function affine2geotransform end
 function geotransform2affine end
 
-# Shared between ArchGDAL and CoordinateTransformations extenstions
+# Shared between ArchGDAL and CoordinateTransformations extensions
 const GDAL_EMPTY_TRANSFORM = [0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
 const GDAL_TOPLEFT_X = 1
 const GDAL_WE_RES = 2

--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -142,7 +142,7 @@ end
 function Mapped(l::Sampled;
     order=order(l), span=span(l), sampling=sampling(l),
     metadata=metadata(l),
-    crs::Union{GeoFormat,Nothing}=nothng,
+    crs::Union{GeoFormat,Nothing}=nothing,
     mappedcrs::Union{GeoFormat,Nothing},
     dim=AutoDim()
 )
@@ -220,7 +220,7 @@ end
 
 Get the bounds converted to the [`mappedcrs`](@ref) value.
 
-Whithout ArchGDAL loaded, this is just the regular bounds.
+Without ArchGDAL loaded, this is just the regular bounds.
 """
 function mappedbounds end
 
@@ -249,7 +249,7 @@ _sort((a, b)) = a <= b ? (a, b) : (b, a)
 
 Get the index value of a dimension converted to the `mappedcrs` value.
 
-Whithout ArchGDAL loaded, this is just the regular dim value.
+Without ArchGDAL loaded, this is just the regular dim value.
 """
 function mappedindex end
 

--- a/src/methods/aggregate.jl
+++ b/src/methods/aggregate.jl
@@ -29,7 +29,7 @@ When the aggregation `scale` of is larger than the array axis, the length of the
 
 - `skipmissingval`: if `true`, any `missingval` will be skipped during aggregation, so that
     only areas of all missing values will be aggregated to `missingval`. If `false`, any
-    aggegrated area containing a `missingval` will be assigned `missingval`.
+    aggregated area containing a `missingval` will be assigned `missingval`.
 $FILENAME_KEYWORD
 $SUFFIX_KEYWORD
 $PROGRESS_KEYWORD
@@ -121,7 +121,7 @@ When the aggregation `scale` of is larger than the array axis, the length of the
 - `progress`: show a progress bar.
 - `skipmissingval`: if `true`, any `missingval` will be skipped during aggregation, so that
     only areas of all missing values will be aggregated to `missingval`. If `false`, any
-    aggegrated area containing a `missingval` will be assigned `missingval`.
+    aggregated area containing a `missingval` will be assigned `missingval`.
 
 Note: currently it is _much_ faster to aggregate over memory-backed arrays.
 Use [`read`](@ref) on `src` before use where required.
@@ -314,11 +314,11 @@ function ag_eltype(method::Tuple{<:Any}, A)
     promote_type(eltype(A), method_returntype)
 end
 
-# Convert indicies from the aggregated array to the larger original array.
+# Convert indices from the aggregated array to the larger original array.
 upsample(index::Int, scale::Int) = (index - 1) * scale + 1
 upsample(index::Int, scale::Colon) = index
 
-# Convert indicies from the original array to the aggregated array.
+# Convert indices from the original array to the aggregated array.
 downsample(index::Int, scale::Int) = (index - 1) ÷ scale + 1
 downsample(index::Int, scale::Colon) = index
 

--- a/src/methods/burning/extents.jl
+++ b/src/methods/burning/extents.jl
@@ -35,7 +35,7 @@ function _extent(::Nothing, data::T; geometrycolumn=nothing)::XYExtent where T
                     acc
                 end
             end
-            return _float64_xy_extent(Extensts.Extent(bounds))
+            return _float64_xy_extent(Extents.Extent(bounds))
         end
     else
         ext = Extents.extent(data)

--- a/src/methods/burning/geometry.jl
+++ b/src/methods/burning/geometry.jl
@@ -96,7 +96,7 @@ function _burn_geometry!(B::AbstractRaster, ::GI.AbstractGeometryTrait, geom;
         # Get the extents of the geometry and array
         geomextent = _extent(geom)
         arrayextent = Extents.extent(B, DEFAULT_POINT_ORDER)
-        # Only fill if the gemoetry bounding box overlaps the array bounding box
+        # Only fill if the geometry bounding box overlaps the array bounding box
         if !Extents.intersects(geomextent, arrayextent) 
             verbose && _verbose_extent_info(geomextent, arrayextent)
             return false

--- a/src/methods/burning/polygon.jl
+++ b/src/methods/burning/polygon.jl
@@ -133,7 +133,7 @@ function _burn_crossings!(A, crossings, ncrossings, iy;
     return BurnStatus(ic, burn, hasburned)
 end
 
-const INTERVALS_INFO = "makes more sense on `Intervals` than `Points` and will have more correct results. You can construct dimensions with a `X(values; sampling=Intervals(Center()))` to acheive this"
+const INTERVALS_INFO = "makes more sense on `Intervals` than `Points` and will have more correct results. You can construct dimensions with a `X(values; sampling=Intervals(Center()))` to achieve this"
 
 @noinline _check_intervals(B) = 
     _chki(B) ? true : (@info "burning lines $INTERVALS_INFO"; false)

--- a/src/methods/coverage.jl
+++ b/src/methods/coverage.jl
@@ -1,11 +1,11 @@
 const COVERAGE_DOC = """
-Calculate the area of a raster covered by GeoInterface.jl compatible geomtry `geom`,
+Calculate the area of a raster covered by GeoInterface.jl compatible geometry `geom`,
 as a fraction.
 
 Each pixel is assigned a grid of points (by default 10 x 10) that are each checked
 to be inside the geometry. The sum divided by the number of points to give coverage.
 
-In pracice, most pixel coverage is not calculated this way - shortcuts that 
+In practice, most pixel coverage is not calculated this way - shortcuts that 
 produce the same result are taken wherever possible.
 
 If `geom` is an `AbstractVector` or table, the `mode` keyword will determine how coverage is combined.
@@ -386,7 +386,7 @@ end
 _buffer_bytes(A, scale) = prod(size(A) .* scale) / 8
 function _check_buffer_mem(A, scale)
     buffer_bytes = _buffer_bytes(A, scale)
-    Sys.free_memory() < buffer_bytes && throw(ArgumentError("Not enought memory for `coverage` at `scale=$scale`. Try a smaller number for the `scale` keyword."))
+    Sys.free_memory() < buffer_bytes && throw(ArgumentError("Not enough memory for `coverage` at `scale=$scale`. Try a smaller number for the `scale` keyword."))
 end
 function _check_buffer_thread_mem(A, scale, threaded::Bool)
     n = threaded ? _nthreads() : 1

--- a/src/methods/crop_extend.jl
+++ b/src/methods/crop_extend.jl
@@ -5,13 +5,13 @@
 Crop one or multiple [`AbstractRaster`](@ref) or [`AbstractRasterStack`](@ref) `x`
 to match the size of the object `to`, or smallest of any dimensions that are shared.
 
-`crop` is lazy, using a `view` into the object rather than alocating new memory.
+`crop` is lazy, using a `view` into the object rather than allocating new memory.
 
 # Keywords
 
 - `to`: the object to crop to. If no `to` keyword is passed, the smallest shared
     area of all `xs` is used.
-- `touches`: `true` or `false`. Whether to use `Touches` wraper on the object extent.
+- `touches`: `true` or `false`. Whether to use `Touches` wrapper on the object extent.
    When lines need to be included in e.g. zonal statistics, `true` should be used.
 
 As `crop` is lazy, `filename` and `suffix` keywords are not used.
@@ -124,7 +124,7 @@ covered by all `xs`, or by the keyword argument `to`.
 
 - `to`: the Raster or dims to extend to. If no `to` keyword is passed, the largest
     shared area of all `xs` is used.
-- `touches`: `true` or `false`. Whether to use `Touches` wraper on the object extent.
+- `touches`: `true` or `false`. Whether to use `Touches` wrapper on the object extent.
    When lines need to be included in e.g. zonal statistics, `true` shoudle be used.
 $FILENAME_KEYWORD
 $SUFFIX_KEYWORD

--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -21,16 +21,16 @@ sliced arrays or stacks will be returned instead of single values.
 
 # Keywords
 
-- `geometry`: include `:geometry` in retured `NamedTuple`, `true` by default.
-- `index`: include `:index` of the `CartesianIndex` in retured `NamedTuple`, `false` by default.
+- `geometry`: include `:geometry` in returned `NamedTuple`, `true` by default.
+- `index`: include `:index` of the `CartesianIndex` in returned `NamedTuple`, `false` by default.
 - `name`: a `Symbol` or `Tuple` of `Symbol` corresponding to layer/s of a `RasterStack` to extract. All layers by default.
 - `skipmissing`: skip missing points automatically.
-- `atol`: a tolorerance for floating point lookup values for when the `Lookup`
+- `atol`: a tolerance for floating point lookup values for when the `Lookup`
     contains `Points`. `atol` is ignored for `Intervals`.
 
 # Example
 
-Here we extact points matching the occurrence of the Mountain Pygmy Possum,
+Here we extract points matching the occurrence of the Mountain Pygmy Possum,
 _Burramis parvus_. This could be used to fit a species distribution model.
 
 ```julia
@@ -322,7 +322,7 @@ end
 end
 
 # _rowtype returns the complete NamedTuple type for a point row
-# This code is entrirely for types stability and performance.
+# This code is entirely for types stability and performance.
 _rowtype(x, g; kw...) = _rowtype(x, typeof(g); kw...)
 _rowtype(x, g::Type; geometry, index, skipmissing, names, kw...) = 
     _rowtype(x, g, geometry, index, skipmissing, names)

--- a/src/methods/mosaic.jl
+++ b/src/methods/mosaic.jl
@@ -199,8 +199,8 @@ function _mosaic(span::Regular, lookup::AbstractSampled, lookups::LookupTuple)
         mi = minimum(map(first, lookups))
         ma = maximum(map(last, lookups))
         if mi isa AbstractFloat
-            # Handle slight range erorrs to make sure
-            # we dont drop one step of the range
+            # Handle slight range errors to make sure
+            # we don't drop one step of the range
             mi:step(span):ma + 2eps(ma)
         else
             mi:step(span):ma
@@ -222,7 +222,7 @@ function _mosaic(::Irregular, lookup::AbstractSampled, lookups::LookupTuple)
     return rebuild(lookup; data=newindex)
 end
 function _mosaic(span::Explicit, lookup::AbstractSampled, lookups::LookupTuple)
-    # TODO make this less fragile to floating point innaccuracy
+    # TODO make this less fragile to floating point inaccuracy
     newindex = sort(union(map(parent, lookups)...); order=LA.ordering(order(lookup)))
     bounds = map(val ∘ DD.span, lookups)
     lower = map(b -> view(b, 1, :), bounds)

--- a/src/methods/rasterize.jl
+++ b/src/methods/rasterize.jl
@@ -136,7 +136,7 @@ function Rasterizer(geom, fill, fillitr;
         !GI.isgeometry(geom) &&
         !GI.trait(first(geom)) isa GI.PointTrait &&
         !(reducer in stable_reductions)
-        @warn "currently `:points` rasterization of multiple non-`PointTrait` geometries may be innaccurate for `reducer` methods besides $stable_reductions. Make a Rasters.jl github issue if you need this to work"
+        @warn "currently `:points` rasterization of multiple non-`PointTrait` geometries may be inaccurate for `reducer` methods besides $stable_reductions. Make a Rasters.jl github issue if you need this to work"
     end
     eltype, missingval, init = get_eltype_missingval(eltype, missingval, fill, fillitr, init, filename, op, reducer)
     lock = threaded ? Threads.SpinLock() : nothing
@@ -144,7 +144,7 @@ function Rasterizer(geom, fill, fillitr;
     return Rasterizer(eltype, geom, fillitr, reducer, op, init, missingval, lock, shape, boundary, verbose, progress, threaded, threadsafe_op)
 end
 function Rasterizer(data::T; fill, geomcolumn=nothing, kw...) where T
-    if Tables.istable(T) # typeof so we dont check iterable table fallback in Tables.jl
+    if Tables.istable(T) # typeof so we don't check iterable table fallback in Tables.jl
         schema = Tables.schema(data)
         cols = Tables.columns(data)
         colnames = Tables.columnnames(Tables.columns(data))
@@ -344,7 +344,7 @@ const RASTERIZE_KEYWORDS = """
     when `data` is a Tables.jl compatible table, or a tuple of `Symbol` for columns of
     point coordinates.
 - `progress`: show a progress bar, `true` by default, `false` to hide..
-- `verbose`: print information and warnings whne there are problems with the rasterisation.
+- `verbose`: print information and warnings when there are problems with the rasterisation.
     `true` by default.
 $THREADED_KEYWORD
 - `threadsafe`: specify that custom `reducer` and/or `op` functions are thread-safe, 
@@ -444,7 +444,7 @@ function rasterize(reducer::typeof(count), data; fill=nothing, init=nothing, kw.
     rasterize(data; kw..., name=:count, init=0, reducer=nothing, fill=_count_fill, missingval=0)
 end
 # `mean` is sum ./ count. This is actually optimal with threading, 
-# as its means order is irrelivent so its threadsafe.
+# as its means order is irrelevant so its threadsafe.
 function rasterize(reducer::typeof(DD.Statistics.mean), data; fill, kw...)
     sums = rasterize(sum, data; kw..., fill)
     counts = rasterize(count, data; kw..., fill=nothing)
@@ -465,7 +465,7 @@ end
 # create_rasterize_dest
 # We create a Raster or RasterStack and apply f to it.
 # This may be on disk, which is the reason for applying f rather than just
-# returning the initiallised object - we may need to open it to be able to write.
+# returning the initialised object - we may need to open it to be able to write.
 create_rasterize_dest(f, r::RasterCreator) = create_rasterize_dest(f, r.eltype, r)
 # function _create_rasterize_dest(f, dims; fill, name=nothing, init=nothing, kw...)
     # _create_rasterize_dest(f, fill, init, name, dims; fill, kw...)
@@ -902,7 +902,7 @@ end
 
 # _apply_reduction!
 #
-# Apply a reducing functin over an iterable
+# Apply a reducing function over an iterable
 # This is applied for all reducing methods that don't have a matching `op` method
 @inline function _apply_reduction!(::Type{T}, f, fill, pixel_geom_list) where T
     any(pixel_geom_list) || return nothing
@@ -950,7 +950,7 @@ Base.@assume_effects :total _choose_fill(op::Nothing, a, fc::FillChooser{<:Funct
 # No op fill is a function, no init fill a (repeated to avoid ambiguity)
 Base.@assume_effects :total _choose_fill(op::Nothing, a, fc::FillChooser{<:Function,Nothing,Missing}) = fc.fill(a)
 # Op is a function, fill is not, missingval===missing
-# apply retudcing op to a and fill, or to init and fill if a equals missing and init exists
+# apply reducing op to a and fill, or to init and fill if a equals missing and init exists
 Base.@assume_effects :total function _choose_fill(op::F, a, fc::FillChooser{<:Any,<:Any,Missing}) where F<:Function
     a1 = ismissing(a) ? fc.init : a
     _apply_op(op, a1, fc.fill)
@@ -967,7 +967,7 @@ Base.@assume_effects :total function _choose_fill(op, a, fc::FillChooser)
     fc.fill
 end
 # Op is a function, fill is not, missingval===missing
-# apply retudcing op to a and fill, or to init and fill if a equals missingval and init exists
+# apply reducing op to a and fill, or to init and fill if a equals missingval and init exists
 # @inline function _choose_fill(a, fill, op::F, init::Nothing, missingval) where F<:Function
 #     _apply_op(op, a, fill)
 # end

--- a/src/methods/reproject.jl
+++ b/src/methods/reproject.jl
@@ -6,7 +6,7 @@ Reproject the lookups of `obj` to a different crs.
 
 This is a lossless operation for the raster data, as only the 
 lookup values change. This is only possible when the axes of source
-and destination projections are alligned: the change is usually from
+and destination projections are aligned: the change is usually from
 a [`Regular`](@ref) and an [`Irregular`](@ref) lookup spans.
 
 For converting between projections that are rotated, 
@@ -59,7 +59,7 @@ _reproject(source::Nothing, target::Nothing, dim, val) = val
 
 function _reproject(source::GeoFormat, target::GeoFormat, dim::Union{XDim,YDim}, val::Number)
     # This is a dumb way to do this. But it save having to inspect crs, 
-    # and prevents reprojections that dont make sense from working.
+    # and prevents reprojections that don't make sense from working.
     # A better method for this should be implemented in future.
     return first(reproject(source, target, dim, [val]))
 end

--- a/src/methods/shared_docstrings.jl
+++ b/src/methods/shared_docstrings.jl
@@ -32,8 +32,8 @@ const THREADED_KEYWORD = """
     can give large speedups over single-threaded operation. This can be true for complicated 
     geometries written into low-resolution rasters, but may not be for simple geometries with 
     high-resolution rasters. With very large rasters threading may be counter productive due 
-    to excessing memory use. Caution should also be used: `threaded` should not be used in in-place 
-    functions wrinting to `BitArray` or other arrays where race conditions can occur. 
+    to excessive memory use. Caution should also be used: `threaded` should not be used in in-place 
+    functions writing to `BitArray` or other arrays where race conditions can occur. 
 """
 
 const GEOM_KEYWORDS = """
@@ -79,7 +79,7 @@ const DROPBAND_KEYWORD = """
 
 const CONSTRUCTOR_CRS_KEYWORD = """
 - `crs`: the coordinate reference system of  the objects `XDim`/`YDim` dimensions.
-    Only set this if you know the detected crs is incrorrect, or it is not present in
+    Only set this if you know the detected crs is incorrect, or it is not present in
     the file. The `crs` is expected to be a GeoFormatTypes.jl `CRS` or `Mixed` mode `GeoFormat` object,
     like `EPSG(4326)`.
 """

--- a/src/methods/trim.jl
+++ b/src/methods/trim.jl
@@ -84,7 +84,7 @@ end
 
 # Tracks the status of an index for some subset of dimensions of an Array
 # This lets us track e.g. the X/Y indices that have only missing values
-# accross all other dimensions.
+# across all other dimensions.
 # This is a hack to work with DiskArrays broadcast chunking without allocations.
 struct AxisTrackers{N,Tr,D,TD} <: AbstractArray{Bool,N}
     tracking::Tr

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -250,7 +250,7 @@ end
 - `Z = YDim`: The Y dimension of the raster.
 - `draw_colorbar = true`: Whether to draw a colorbar for the axis or not.
 - `colorbar_position = Makie.Right()`: Indicates which side of the axis the colorbar should be placed on.  Can be `Makie.Top()`, `Makie.Bottom()`, `Makie.Left()`, or `Makie.Right()`.
-- `colorbar_padding = Makie.automatic`: The amound of padding between the colorbar and its axis.  If `automatic`, then this is set to the width of the colorbar.
+- `colorbar_padding = Makie.automatic`: The amount of padding between the colorbar and its axis.  If `automatic`, then this is set to the width of the colorbar.
 - `title = Makie.automatic`: The titles of each plot. If `automatic`, these are set to the name of the band.
 - `xlabel = Makie.automatic`: The x-label for the axis. If `automatic`, set to the dimension name of the X-dimension of the raster.
 - `ylabel = Makie.automatic`: The y-label for the axis. If `automatic`, set to the dimension name of the Y-dimension of the raster.

--- a/src/series.jl
+++ b/src/series.jl
@@ -32,7 +32,7 @@ Apply function `f` to the data of the child object.
 If the child is an `AbstractRasterStack` the function will
 be passed on to its child `AbstractRaster`s.
 
-`f` must return an idenically sized array.
+`f` must return an identically sized array.
 
 This method triggers a complete rebuild of all objects,
 and disk based objects will be transferred to memory.
@@ -77,7 +77,7 @@ julia> ser = RasterSeries("series_dir/myseries.tif", Ti(DateTime))
   Ti Sampled{DateTime} DateTime[DateTime("2001-01-01T00:00:00"), DateTime("2002-01-01T00:00:00")] ForwardOrdered Irregular Points
 ```
 
-The `DateTime` suffix is parsed from the filenames. Using `Ti(Int)` would try to parse integers intead.
+The `DateTime` suffix is parsed from the filenames. Using `Ti(Int)` would try to parse integers instead.
 
 Just using the directory will also work, unless there are other files mixed in it:
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -43,7 +43,7 @@ function print_geo(io, mime, A; blockwidth)
 end
 
 
-# Stack types can be enourmous. Just use nameof(T)
+# Stack types can be enormous. Just use nameof(T)
 function Base.summary(io::IO, ser::AbstractRasterSeries{T,N}) where {T,N}
     if N == 0  
         print(io, "0-dimensional ")

--- a/src/sources/commondatamodel.jl
+++ b/src/sources/commondatamodel.jl
@@ -63,7 +63,7 @@ function DiskArrays.writeblock!(A::CFDiskArray, data, i::AbstractUnitRange...)
     return data
 end
 
-# We have to dig down to find the chunks as they are not immplemented
+# We have to dig down to find the chunks as they are not implemented
 # in the CDM, but they are in their internal objects.
 DiskArrays.eachchunk(var::CFDiskArray) = _get_eachchunk(var)
 DiskArrays.haschunks(var::CFDiskArray) = _get_haschunks(var)
@@ -244,7 +244,7 @@ end
 
 # Utils ########################################################################
 
-# TODO dont load all keys here with _layers
+# TODO don't load all keys here with _layers
 _firstname(ds::AbstractDataset, name) = Symbol(name)
 function _firstname(ds::AbstractDataset, name::NoKW=nokw)
     names = _nondimnames(ds)
@@ -280,7 +280,7 @@ function _cdmfinddimlen(ds, dimname)
             return size(var)[findfirst(==(dimname), dimnames)]
         end
     end
-    return nothsng
+    return nothing
 end
 
 # Find the matching dimension constructor. If its an unknown name
@@ -450,7 +450,7 @@ end
 _attribdict(md::Metadata{<:CDMsource}) = Dict{String,Any}(string(k) => v for (k, v) in md)
 _attribdict(md) = Dict{String,Any}()
 
-# Add axis and standard name attributes to dimension variabls
+# Add axis and standard name attributes to dimension variables
 # We need to get better at guaranteeing if X/Y is actually measured in `longitude/latitude`
 # CF standards requires that we specify "units" if we use these standard names
 _cdm_set_axis_attrib!(atr, dim::X) = atr["axis"] = "X" # at["standard_name"] = "longitude";

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -1,4 +1,4 @@
-# Accept either Symbol or String keys, but allways convert to Symbol
+# Accept either Symbol or String keys, but always convert to Symbol
 const Key = Union{Symbol,AbstractString}
 
 const MAX_STACK_SIZE = 200
@@ -239,7 +239,7 @@ function RasterStack(data::NamedTuple{<:Any,<:Tuple{Vararg{<:AbstractArray}}}, d
 )
     if isnokw(layerdims)
         # TODO: make this more sophisticated and match dimension length to axes?
-        # We dont worry about Raster keywords because these rasters will be deconstructed 
+        # We don't worry about Raster keywords because these rasters will be deconstructed 
         # again later, and `kw` will define the RasterStack keywords
         layers = map(data) do A
             Raster(A, dims[1:ndims(A)])
@@ -552,7 +552,7 @@ end
 
 
 function _layerkeysfromdim(A, dim)
-    hasdim(A, dim) || throw(ArgumentError("`layersrom` dim `$(name(dim))` not found in `$(map(basetypeof, dims(A)))`"))
+    hasdim(A, dim) || throw(ArgumentError("`layersfrom` dim `$(name(dim))` not found in `$(map(basetypeof, dims(A)))`"))
     vals = parent(lookup(A, dim))
     l = length(vals)
     if l > MAX_STACK_SIZE

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -34,7 +34,7 @@ function _maybe_use_type_missingval(A::AbstractRaster{T}, source::Source, missin
     end
 end
 
-# Create a standardisted Metadata object of source T, containing a `Dict{String,Any}`
+# Create a standardised Metadata object of source T, containing a `Dict{String,Any}`
 _metadatadict(s::Source, p1::Pair, pairs::Pair...) = 
     _metadatadict(s, (p1, pairs...))
 _metadatadict(::S) where S<:Source = Metadata{S}(Dict{String,Any}())

--- a/src/write.jl
+++ b/src/write.jl
@@ -5,7 +5,7 @@ const CHUNKS_KEYWORD = """
     or a `NamedTuple` of `Int` can be used. Other dimensions will have a chunk
     size of `1`. `true` can be used to mean: use the original 
     chunk size of the lazy `Raster` being written or X and Y of 256 by 256.
-    `false` means dont use chunks at all.
+    `false` means don't use chunks at all.
 """
 
 const MISSINGVAL_KEYWORD = """

--- a/test/array.jl
+++ b/test/array.jl
@@ -41,7 +41,7 @@ end
     @test mappedcrs(gampr) == mappedcrs(gampr[X(1)]) == EPSG(4326)
 end
 
-@testset "arary dims have been formatted" begin
+@testset "array dims have been formatted" begin
     @test index(ga2) == (10.0:10:100, -50.0:10:50.0, [DateTime(2019)])
     @test dims(ga1)[1:2] == dims(ga2)[1:2]
 end

--- a/test/rasterize.jl
+++ b/test/rasterize.jl
@@ -351,7 +351,7 @@ end
      0 0 0 0 0 0 0
      0 0 0 0 0 0 0]
 end
-# GDAL doesnt do inside / not touching rasterization, so we have no test against GDAL
+# GDAL doesn't do inside / not touching rasterization, so we have no test against GDAL
 @testset "line inside rasterization" begin
     @time gdal_raster = gdal_read_rasterize(shppath, "-at")
     rasters_inside_raster = rasterize(last, shphandle.shapes; 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ if !Sys.iswindows()
     @time @safetestset "gribdatasets" begin include("sources/gribdatasets.jl") end
 end
 
-# Only test SMAP locally for now, also RasterDataSources because CI dowloads keep breaking
+# Only test SMAP locally for now, also RasterDataSources because CI downloads keep breaking
 if !haskey(ENV, "CI")
     @time @safetestset "rasterdatasources" begin include("sources/rasterdatasources.jl") end
 end

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -112,7 +112,7 @@ gdalpath = maybedownload(url)
     end
 
     @testset "other fields" begin
-        # This file has an inorrect missing value
+        # This file has an incorrect missing value
         @test missingval(gdalarray) === nothing
         @test metadata(gdalarray) isa Metadata{GDALsource,Dict{String,Any}} 
         @test basename(metadata(gdalarray)["filepath"]) == "cea.tif"
@@ -441,7 +441,7 @@ gdalpath = maybedownload(url)
             @test all(bounds(saved, Y) .≈ bounds(clat))
             @test projectedindex(clon) ≈ projectedindex(saved, X)
             @test all(projectedbounds(clon) .≈ projectedbounds(saved, X))
-            # reason lat crs conversion is less accrurate than lon TODO investigate further
+            # reason lat crs conversion is less accurate than lon TODO investigate further
             @test all(map((a, b) -> isapprox(a, b; rtol=1e-6),
                 projectedindex(gdalarray, Y),
                 projectedindex(DimensionalData.shiftlocus(Start(), dims(saved, Y)))

--- a/test/sources/rasterdatasources.jl
+++ b/test/sources/rasterdatasources.jl
@@ -96,7 +96,7 @@ if Sys.islinux()
         A = Raster(AWAP, :rainfall; date=DateTime(2019, 10, 19), lazy=true)
         @test crs(A) == EPSG(4326)
         # ALWB :solar has a broken index - the size is different and the
-        # points dont exactly match the other layers.
+        # points don't exactly match the other layers.
         # Need to work out how to best resolve this kind of problem so that we can
         # still use the layers in stacks.
         layers = (:rainfall, :vprpress09, :vprpress15, :tmin, :tmax)


### PR DESCRIPTION
@rafaqz

Note the effect of running the `sed` lines.

If you don't want those changes I will revert them.

```
sed -i "s/isalligned/isaligned/g" Rasters.jl/ext/RastersArchGDALExt/gdal_source.jl
sed -i "s/unalligned/unaligned/g" Rasters.jl/ext/RastersCoordinateTransformationsExt/affineprojected.jl

```