### PR TITLE
fix vector element type in zonal pre-allocation

### DIFF
--- a/src/methods/zonal.jl
+++ b/src/methods/zonal.jl
@@ -108,16 +108,31 @@ function _zonal(f, x::RasterStackOrArray, ::Nothing, data; progress=true, thread
     geoms = _get_geometries(data, geometrycolumn)
     n = length(geoms)
     n == 0 && return []
-    zs = _alloc_zonal(f, x, first(geoms), n; kw...)
-    _run(1:n, threaded, progress, "Applying $f to each geometry...") do i
+    zs = _alloc_zonal(f, x, geoms, n; kw...)
+    start_index = findfirst(x -> !ismissing(x), zs)
+    isnothing(start_index) && return zs
+    _run(start_index:n, threaded, progress, "Applying $f to each geometry...") do i
         zs[i] = _zonal(f, x, geoms[i]; kw...)
     end
     return zs
 end
 
-function _alloc_zonal(f, x, geom, n; kw...)
-    z1 = _zonal(f, x, geom; kw...)
+function _alloc_zonal(f, x, geoms, n; kw...)
+    # Find first non-missing entry
+    n_missing::Int = 0
+    z1 = _zonal(f, x, first(geoms); kw...)
+    for geom in geoms
+        z1 = _zonal(f, x, geom; kw...)
+        if !ismissing(z1)
+            break
+        end
+        n_missing += 1
+    end
     zs = Vector{Union{Missing,typeof(z1)}}(undef, n)
-    zs[1] = z1
+    zs[1:n_missing] .= missing
+    if n_missing == n
+        return zs
+    end
+    zs[n_missing + 1] = z1
     return zs
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -299,6 +299,16 @@ end
         zonal(sum, st; of=dims(st)) == 
         zonal(sum, st; of=Extents.extent(st)) == 
         sum(st)
+
+    a = Raster((1:26) * (1:31)', (X(-20:5), Y(0:30)))
+    out_bounds_pointvec = [(-40.0, -40.0), (-40.0, -35.0), (-35.0, -35.0), (-35.0, -40.0)]
+    out_bounds_polygon = ArchGDAL.createpolygon(out_bounds_pointvec)
+    @test ismissing(zonal(sum, a; of=[polygon, out_bounds_polygon, polygon])[2]) &&
+        ismissing(zonal(sum, a; of=[out_bounds_polygon, polygon])[1]) &&
+        ismissing(zonal(sum, a; of=(geometry=out_bounds_polygon, x=:a, y=:b))) &&
+        ismissing(zonal(sum, a; of=[(geometry=out_bounds_polygon, x=:a, y=:b)])[1])
+    @test zonal(sum, a; of=[out_bounds_polygon, out_bounds_polygon, polygon])[3] == 
+        sum(skipmissing(mask(a; with=polygon)))
 end
 
 @testset "classify" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -299,7 +299,9 @@ end
         zonal(sum, st; of=dims(st)) == 
         zonal(sum, st; of=Extents.extent(st)) == 
         sum(st)
+end
 
+@testset "zonal_return_missing" begin
     a = Raster((1:26) * (1:31)', (X(-20:5), Y(0:30)))
     out_bounds_pointvec = [(-40.0, -40.0), (-40.0, -35.0), (-35.0, -35.0), (-35.0, -40.0)]
     out_bounds_polygon = ArchGDAL.createpolygon(out_bounds_pointvec)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -301,7 +301,7 @@ end
         sum(st)
 end
 
-@testset "zonal_return_missing" begin
+@testset "zonal return missing" begin
     a = Raster((1:26) * (1:31)', (X(-20:5), Y(0:30)))
     out_bounds_pointvec = [(-40.0, -40.0), (-40.0, -35.0), (-35.0, -35.0), (-35.0, -40.0)]
     out_bounds_polygon = ArchGDAL.createpolygon(out_bounds_pointvec)


### PR DESCRIPTION
If the aggregation function returns missing with the first geometry mask in `zonal` then the function will error with

```
nested task error: cannot convert a value to missing for assignment
``` 

In order to determine the element type of the vector for pre-allocation, `_alloc_zonal` calculates the first value of the vector to be returned separately and uses it's type when pre-allocating.
See [here](https://github.com/rafaqz/Rasters.jl/blob/main/src/methods/zonal.jl#L118-L123)
```julia
function _alloc_zonal(f, x, geom, n; kw...)
    z1 = _zonal(f, x, geom; kw...)
    zs = Vector{Union{Missing,typeof(z1)}}(undef, n)
    zs[1] = z1
    return zs
end
```
However, if the first element is missing then `zs = Vector{Union{Missing, Missing}}(undef, n)`. 

This proposed change uses the first non-missing type as the type of the Vector.