### PR TITLE
combine using DiskArrays.ConcatDiskArary

### DIFF
--- a/src/methods/crop_extend.jl
+++ b/src/methods/crop_extend.jl
@@ -67,7 +67,6 @@ savefig("build/argentina_crop_example.png"); nothing
 
 $EXPERIMENTAL
 """
-
 function crop end
 function crop(l1::RasterStackOrArray, l2::RasterStackOrArray, ls::RasterStackOrArray...; kw...)
     crop((l1, l2, ls...); kw...)

--- a/src/methods/slice_combine.jl
+++ b/src/methods/slice_combine.jl
@@ -68,5 +68,5 @@ function _combine(ser::AbstractRasterSeries{<:AbstractRasterStack{K}}; kw...) wh
         _combine(map(s -> s[k], ser); kw...)
     end |> NamedTuple{K}
     newdims = combinedims(new_layers...)
-    rebuild(r1; data = new_layers, dims = newdims, refdims = otherdims(dims(r1), newdims))
+    DimensionalData.rebuild_from_arrays(r1, new_layers; refdims=otherdims(dims(r1), newdims))
 end

--- a/src/methods/slice_combine.jl
+++ b/src/methods/slice_combine.jl
@@ -42,8 +42,11 @@ If `lazy`, concatenate lazily. The default is to concatenate lazily for lazy `Ra
 
 $EXPERIMENTAL
 """
-combine(ser::AbstractRasterSeries, dims; kw...) = combine(ser; dims, kw...)
-function combine(ser::AbstractRasterSeries; dims, lazy = isdisk(ser))
+function combine(ser::AbstractRasterSeries; dims=nokw, kw...)
+    isnokw(dims) ? _combine(ser; kw...) : _combine(ser, dims; kw...)
+end
+combine(ser::AbstractRasterSeries, dims; kw...) = _combine(ser, dims; kw...)
+function _combine(ser::AbstractRasterSeries, dims; lazy=isdisk(ser))
     ods = otherdims(ser, dims)
     if length(ods) > 0
         map(x -> combine(x; lazy), eachslice(ser; dims = ods))
@@ -51,7 +54,7 @@ function combine(ser::AbstractRasterSeries; dims, lazy = isdisk(ser))
         combine(ser; lazy)
     end
 end
-function combine(ser::AbstractRasterSeries; lazy = isdisk(ser))
+function _combine(ser::AbstractRasterSeries; lazy = isdisk(ser))
     ras1 = first(ser)
     alldims = (dims(ras1)..., dims(ser)...)
     ser_res = DD._insert_length_one_dims(ser, alldims)

--- a/src/methods/slice_combine.jl
+++ b/src/methods/slice_combine.jl
@@ -30,7 +30,7 @@ slice(ser::AbstractRasterSeries, dims) = cat(map(x -> slice(x, dims), ser)...; d
     throw(ArgumentError("Dimensions $(map(name, targets)) were not found in $(map(name, dims))"))
 
 """
-    combine(A::Union{AbstractRaster,AbstractRasterStack,AbstracRasterSeries}, [dims]) => Raster
+    combine(A::AbstracRasterSeries; [dims], [lazy]) => Raster
 
 Combine a `RasterSeries` along some dimension/s, creating a new `Raster` or `RasterStack`,
 depending on the contents of the series.
@@ -38,61 +38,24 @@ depending on the contents of the series.
 If `dims` are passed, only the specified dimensions will be combined
 with a `RasterSeries` returned, unless `dims` is all the dims in the series.
 
+If `lazy`, concatenate lazily. The default is to concatenate lazily for lazy `Raster`s and eagerly otherwise.
+
 $EXPERIMENTAL
 """
-function combine(ser::AbstractRasterSeries, dims)
+combine(ser::AbstractRasterSeries, dims; kw...) = combine(ser; dims, kw...)
+function combine(ser::AbstractRasterSeries; dims, lazy = isdisk(ser))
     ods = otherdims(ser, dims)
     if length(ods) > 0
-        map(DimIndices(ods)) do D
-            combine(view(ser, D...))
-        end |> RasterSeries
+        map(x -> combine(x; lazy), eachslice(ser; dims = ods))
     else
-        combine(ser)
+        combine(ser; lazy)
     end
 end
-function combine(ser::AbstractRasterSeries{<:Any,N}) where N
-    r1 = first(ser)
-    dest = _alloc_combine_dest(ser)
-    for sD in DimIndices(ser)
-        rD = map(d -> rebuild(d, :), DD.dims(r1))
-        source = ser[sD...]
-        if dest isa RasterStack
-            foreach(layers(source), layers(dest)) do source_r, dest_r
-                view(dest_r, rD..., sD...) .= source_r
-            end
-        else
-            # TODO we shouldn't need a view here??
-            view(dest, rD..., sD...) .= source
-        end
-    end
-    return dest
-end
-
-_alloc_combine_dest(s::AbstractRasterSeries) = _alloc_combine_dest(first(s), s)
-_alloc_combine_dest(r::AbstractRaster, s) = similar(r, (dims(r)..., dims(s)...))
-_alloc_combine_dest(r::AbstractRasterStack, s) = map(r -> _alloc_combine_dest(r, s), first(s))
-
-function _maybereshape(A::AbstractRaster{<:Any,N}, acc, dim) where N
-    if ndims(acc) != ndims(A)
-        newdata = reshape(parent(A), Val{N+1}())
-        d = if hasdim(refdims(A), dim)
-            dims(refdims(A), dim)
-        else
-            DD.basetypeof(dim)(1:1; lookup=NoLookup())
-        end
-        newdims = (DD.dims(A)..., d)
-        return rebuild(A; data=newdata, dims=newdims)
-    else
-        return A
-    end
-end
-function _maybereshape(st::AbstractRasterStack, acc, dim)
-    map((s, a) -> _maybereshape(s, a, dim), st, acc)
-end
-
-# See iterate(::GridChunks) in Diskarrays.jl
-function _chunk_inds(g, ichunk)
-    outinds = map(ichunk.I, g.chunksize, g.parentsize, g.offset) do ic, cs, ps, of
-        max((ic - 1) * cs + 1 -of, 1):min(ic * cs - of, ps)
-    end
+function combine(ser::AbstractRasterSeries; lazy = isdisk(ser))
+    ras1 = first(ser)
+    alldims = (dims(ras1)..., dims(ser)...)
+    ser_res = DD._insert_length_one_dims(ser, alldims)
+    data = DA.ConcatDiskArray(ser_res)
+    data = lazy ? data : collect(data)
+    return rebuild(ras1; data, dims = alldims)
 end

--- a/test/series.jl
+++ b/test/series.jl
@@ -91,11 +91,11 @@ end
     ser = slice(stack, Ti)
     @test size(ser) == (10,)
     combined = Rasters.combine(ser, Ti)
+    dims(first(combined))
     ser = slice(stack, (Y, Ti))
     @test size(ser) == (5, 10,)
     combined = Rasters.combine(ser, (Y, Ti))
 end
-
 
 @testset "show" begin
     # 2d


### PR DESCRIPTION
improves `combine` to work lazily. Should be much faster than the previous implementation.