### PR TITLE
define isdisk for AbstractRasterSeries

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -24,6 +24,7 @@ abstract type AbstractRasterSeries{T,N,D,A} <: AbstractDimArray{T,N,D,A} end
 DD.metadata(A::AbstractRasterSeries) = NoMetadata()
 DD.name(A::AbstractRasterSeries) = NoName()
 DD.label(A::AbstractRasterSeries) = ""
+isdisk(A::AbstractRasterSeries) = isdisk(first(A))
 
 """
     modify(f, series::AbstractRasterSeries)

--- a/src/series.jl
+++ b/src/series.jl
@@ -21,10 +21,10 @@ abstract type AbstractRasterSeries{T,N,D,A} <: AbstractDimArray{T,N,D,A} end
 
 # Interface methods ####################################################
 
-DD.metadata(A::AbstractRasterSeries) = NoMetadata()
-DD.name(A::AbstractRasterSeries) = NoName()
+DD.metadata(A::AbstractRasterSeries) = DD.metadata(first(A))
+DD.name(A::AbstractRasterSeries) = DD.name(first(A))
 DD.label(A::AbstractRasterSeries) = ""
-isdisk(A::AbstractRasterSeries) = any(isdisk, A))
+isdisk(A::AbstractRasterSeries) = any(isdisk, A)
 
 """
     modify(f, series::AbstractRasterSeries)

--- a/src/series.jl
+++ b/src/series.jl
@@ -21,8 +21,8 @@ abstract type AbstractRasterSeries{T,N,D,A} <: AbstractDimArray{T,N,D,A} end
 
 # Interface methods ####################################################
 
-DD.metadata(A::AbstractRasterSeries) = DD.metadata(first(A))
-DD.name(A::AbstractRasterSeries) = DD.name(first(A))
+DD.metadata(A::AbstractRasterSeries) = NoMetadata()
+DD.name(A::AbstractRasterSeries) = NoName()
 DD.label(A::AbstractRasterSeries) = ""
 isdisk(A::AbstractRasterSeries) = any(isdisk, A)
 

--- a/src/series.jl
+++ b/src/series.jl
@@ -24,7 +24,7 @@ abstract type AbstractRasterSeries{T,N,D,A} <: AbstractDimArray{T,N,D,A} end
 DD.metadata(A::AbstractRasterSeries) = NoMetadata()
 DD.name(A::AbstractRasterSeries) = NoName()
 DD.label(A::AbstractRasterSeries) = ""
-isdisk(A::AbstractRasterSeries) = isdisk(first(A))
+isdisk(A::AbstractRasterSeries) = any(isdisk, A))
 
 """
     modify(f, series::AbstractRasterSeries)

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -34,7 +34,7 @@ missingval(s::AbstractRasterStack, name::Symbol) = _singlemissingval(missingval(
 filename(stack::AbstractRasterStack{<:Any,<:Any,<:Any,<:NamedTuple}) = map(s -> filename(s), stack)
 filename(stack::AbstractRasterStack{<:Any,<:Any,<:Any,<:Union{FileStack,OpenStack}}) = filename(parent(stack))
 
-isdisk(st::AbstractRasterStack) = isdisk(layers(st, 1))
+isdisk(st::AbstractRasterStack) = any(isdisk, layers(st))
 
 setcrs(x::AbstractRasterStack, crs) = set(x, setcrs(dims(x), crs)...)
 setmappedcrs(x::AbstractRasterStack, mappedcrs) = set(x, setmappedcrs(dims(x), mappedcrs)...)

--- a/test/series.jl
+++ b/test/series.jl
@@ -123,6 +123,7 @@ end
         first_dims = dims(first(series))
         @test all(dims(r) == first_dims for r in series)
         @test Rasters.isdisk(series)
+        @test !Rasters.isdisk(read(series))
         @test Rasters.isdisk(Rasters.combine(series))
         end
 end

--- a/test/series.jl
+++ b/test/series.jl
@@ -122,5 +122,7 @@ end
         @test all(Rasters.filename.(series) .== filenames)
         first_dims = dims(first(series))
         @test all(dims(r) == first_dims for r in series)
-    end
+        @test Rasters.isdisk(series)
+        @test Rasters.isdisk(Rasters.combine(series))
+        end
 end

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -586,6 +586,7 @@ end
 
     @testset "lazy" begin
         gdalstack_lazy = RasterStack((a=gdalpath, b=gdalpath); lazy=true)
+        @test Rasters.isdisk(gdalstack_lazy)
         @test Rasters.isdisk(gdalstack_lazy.a)
         @test Rasters.isdisk(gdalstack_lazy.b)
         gdalstack_read = read(gdalstack_lazy)


### PR DESCRIPTION
`isdisk` was not defined for AbstractRasterSeries and therefore defaulted to `false`, making `combine` incredibly slow for lazy `AbstractRasterSeries`.

In this PR it just looks at the first raster in the series, which I'm sure there are some edge cases where it doesn't work, but `AbstractRasterStack` does the very same thing.

We might want to define things like `metadata` and `name` as well?