### PR TITLE
ditch SurfaceLikeCompat to remove method ambiguity

### DIFF
--- a/ext/RastersMakieExt/plotrecipes.jl
+++ b/ext/RastersMakieExt/plotrecipes.jl
@@ -294,9 +294,17 @@ end
 function Makie.convert_arguments(t::Makie.PointBased, A::AbstractRaster{<:Number,2})
     return Makie.convert_arguments(t, _prepare_dimarray(A))
 end
-function Makie.convert_arguments(t::SurfaceLikeCompat, A::AbstractRaster{<:Any,2})
-    return Makie.convert_arguments(t, _prepare_dimarray(A))
+@static if isdefined(Makie, :SurfaceLike)
+
+    function Makie.convert_arguments(t::SurfaceLikeCompat, A::AbstractRaster{var"#s115", 2, D}) where {var"#s115", D<:Tuple}
+        return Makie.convert_arguments(t, _prepare_dimarray(A))
+    end
+else # surfacelike is not a thing
+    Makie.convert_arguments(t::Makie.VertexGrid, A::AbstractRaster{<: Any, 2}) = Makie.convert_arguments(t, _prepare_dimarray(A))
+    Makie.convert_arguments(t::Makie.CellGrid, A::AbstractRaster{<: Any, 2}) = Makie.convert_arguments(t, _prepare_dimarray(A))
+    Makie.convert_arguments(t::Makie.ImageLike, A::AbstractRaster{<: Any, 2}) = Makie.convert_arguments(t, _prepare_dimarray(A))
 end
+
 function Makie.convert_arguments(t::Makie.DiscreteSurface, A::AbstractRaster{<:Any,2})
     return Makie.convert_arguments(t, _prepare_dimarray(A))
 end

--- a/ext/RastersMakieExt/plotrecipes.jl
+++ b/ext/RastersMakieExt/plotrecipes.jl
@@ -296,7 +296,7 @@ function Makie.convert_arguments(t::Makie.PointBased, A::AbstractRaster{<:Number
 end
 @static if isdefined(Makie, :SurfaceLike)
 
-    function Makie.convert_arguments(t::SurfaceLikeCompat, A::AbstractRaster{var"#s115", 2, D}) where {var"#s115", D<:Tuple}
+    function Makie.convert_arguments(t::SurfaceLike, A::AbstractRaster{var"#s115", 2, D}) where {var"#s115", D<:Tuple}
         return Makie.convert_arguments(t, _prepare_dimarray(A))
     end
 else # surfacelike is not a thing


### PR DESCRIPTION
I thought I opened an issue about this but couldn't find it.  This just squashes a method ambiguity which was previously disguised because DDMakieExt and RastersMakieExt both override the common Makie plot functions.  This failed when I was trying to use `GeoMakie.meshimage` with a raster.