### PR TITLE
Drop Requires.jl code in __init__

### DIFF
--- a/src/Rasters.jl
+++ b/src/Rasters.jl
@@ -144,17 +144,4 @@ include("sources/grd.jl")
 include("sources/commondatamodel.jl")
 include("extensions.jl")
 
-# Compatibility with pre-1.9 julia
-function __init__()
-    @static if !isdefined(Base, :get_extension)
-        @require ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3" include("../ext/RastersArchGDALExt/RastersArchGDALExt.jl")
-        @require CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298" include("../ext/RastersCoordinateTransformationsExt/RastersCoordinateTransformationsExt.jl")
-        @require HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" include("../ext/RastersHDF5Ext/RastersHDF5Ext.jl")
-        @require Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("../ext/RastersMakieExt/RastersMakieExt.jl")
-        @require NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab" include("../ext/RastersNCDatasetsExt/RastersNCDatasetsExt.jl")
-        @require GRIBDatasets = "82be9cdb-ee19-4151-bdb3-b400788d9abc" include("../ext/RastersGRIBDatasetsExt/RastersGRIBDatasetsExt.jl")
-        @require RasterDataSources = "3cb90ccd-e1b6-4867-9617-4276c8b2ca36" include("../ext/RastersRasterDataSourcesExt/RastersRasterDataSourcesExt.jl")
-    end
-end
-
 end


### PR DESCRIPTION
It's not in the Project.toml anyway, and the Julia compat is set to 1.10 so this code can never run