### PR TITLE
Fix Zarr datasets not picking up CF encoded scale/offset factors

### DIFF
--- a/ext/RastersZarrDatasetsExt/zarrdatasets_source.jl
+++ b/ext/RastersZarrDatasetsExt/zarrdatasets_source.jl
@@ -16,6 +16,11 @@ RA._sourcetrait(::ZD.ZarrDataset) = Zarrsource()
 RA.missingval(var::ZD.ZarrVariable, args...) = RA.missingval(RA.Metadata{Zarrsource}(CDM.attribs(var)))
 RA.missingval(var::ZD.ZarrVariable, md::RA.Metadata{<:Zarrsource}) = RA.missingval(md)
 
+@inline function RA.get_scale(metadata::RA.Metadata{<: Zarrsource}, scaled::Bool)
+    scale = scaled ? get(metadata, "scale_factor", nothing) : nothing
+    offset = scaled ? get(metadata, "add_offset", nothing) : nothing
+    return scale, offset
+end
 # TODO: handle multiple missing values
 function RA.missingval(md::RA.Metadata{<:Zarrsource})
     fv = get(md, "_FillValue", nothing)


### PR DESCRIPTION
This fixes a strange issue I was having where Rasters.jl read the wrong values from a Kerchunk/Zarr dataset.

Based off the `cf` branch, I'm not sure if `get_scale` is added there or is also on the main branch.  Can rebase to main if it doesn't need cf.