### PR TITLE
Print a styled backend error message so it's more eye-catching

### DIFF
--- a/src/sources/sources.jl
+++ b/src/sources/sources.jl
@@ -59,7 +59,7 @@ end
 # error message to show when backend is not loaded
 function Base.showerror(io::IO, e::BackendException)
     printstyled(io, "Rasters.jl"; underline = true)
-    printstyled(io, " requires backends to be loaded externally as of version 0.8.  Run ")
+    printstyled(io, " requires backends to be loaded manually.  Run ")
     printstyled(io, "`import $(e.backend)`"; bold = true)
     print(io, "to fix this error.")
 end

--- a/src/sources/sources.jl
+++ b/src/sources/sources.jl
@@ -58,7 +58,10 @@ end
 
 # error message to show when backend is not loaded
 function Base.showerror(io::IO, e::BackendException)
-    print(io, "`Rasters.jl` requires backends to be loaded externally as of version 0.8. Run `import $(e.backend)` to fix this error.")
+    printstyled(io, "Rasters.jl"; underline = true)
+    printstyled(io, " requires backends to be loaded externally as of version 0.8.  Run ")
+    printstyled(io, "`import $(e.backend)`"; bold = true)
+    print(io, "to fix this error.")
 end
 
 # Get the source backend for a file extension, falling back to GDALsource


### PR DESCRIPTION
<img width="1034" alt="Screenshot 2024-10-02 at 2 09 57 PM" src="https://github.com/user-attachments/assets/7bd1c560-3799-48e7-a282-7387df4a4ca4">
