### PR TITLE
Halve the number of calls to cosd, sind in spherical `cellarea`

### DIFF
--- a/ext/RastersProjExt/cellarea.jl
+++ b/ext/RastersProjExt/cellarea.jl
@@ -38,9 +38,11 @@ end
 
 _lonlat_to_sphericalpoint(args) = _lonlat_to_sphericalpoint(args...)
 function _lonlat_to_sphericalpoint(lon, lat)
-    x = cosd(lat) * cosd(lon)
-    y = cosd(lat) * sind(lon)
-    z = sind(lat)
+    lonsin, loncos = sincosd(lon)
+    latsin, latcos = sincosd(lat)
+    x = latcos * loncos
+    y = latcos * lonsin
+    z = latsin
     return SphericalPoint(x,y,z)
 end
 


### PR DESCRIPTION
by using `sincosd` instead.
Using the MWE from #779 ,

Before
```julia
julia> @be Rasters.cellarea(Spherical(), ras2) seconds=30
Benchmark: 12 samples with 1 evaluation
 min    2.649 s (11115638 allocs: 1.532 GiB, 3.00% gc time)
 median 2.695 s (11115638 allocs: 1.532 GiB, 3.40% gc time)
 mean   2.706 s (11115639 allocs: 1.532 GiB, 3.84% gc time)
 max    2.763 s (11115642 allocs: 1.532 GiB, 5.76% gc time)
```
After
```
julia> @be Rasters.cellarea(Spherical(), ras2) seconds=30
Benchmark: 12 samples with 1 evaluation
 min    2.429 s (11115638 allocs: 1.532 GiB, 3.26% gc time)
 median 2.450 s (11115638 allocs: 1.532 GiB, 3.58% gc time)
 mean   2.565 s (11115648 allocs: 1.532 GiB, 3.89% gc time, <0.01% compile time)
 max    3.426 s (11115749 allocs: 1.532 GiB, 5.00% gc time, 0.08% compile time)
```

It's a marginal improvement but every bit counts...