### PR TITLE
Add tests for unitful `cellarea`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -102,7 +102,8 @@ RasterDataSources = "3cb90ccd-e1b6-4867-9617-4276c8b2ca36"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Shapefile = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ArchGDAL", "CFTime", "CoordinateTransformations", "DataFrames", "GeoDataFrames", "GeometryBasics", "GRIBDatasets", "NCDatasets", "Plots", "Proj", "RasterDataSources", "SafeTestsets", "Shapefile", "Statistics", "Test", "ZarrDatasets"]
+test = ["Aqua", "ArchGDAL", "CFTime", "CoordinateTransformations", "DataFrames", "GeoDataFrames", "GeometryBasics", "GRIBDatasets", "NCDatasets", "Plots", "Proj", "RasterDataSources", "SafeTestsets", "Shapefile", "Statistics", "Test", "Unitful", "ZarrDatasets"]

--- a/test/cellarea.jl
+++ b/test/cellarea.jl
@@ -1,6 +1,7 @@
 using Rasters, DimensionalData, Rasters.Lookups, Proj
 using Test
 using DimensionalData: @dim, YDim
+import Unitful
 include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
 
 @testset "cellarea" begin
@@ -70,4 +71,28 @@ include(joinpath(dirname(pathof(Rasters)), "../test/test_utils.jl"))
     # test missing crs throws an error
     nocrsdimz = setcrs(dimz, nothing)
     @test_throws ArgumentError cellarea(nocrsdimz)
+
+    @testset "Unitful cellarea" begin
+         # Case 1: cellarea with unitful manifold
+         # This is the simplest case
+         unitful_manifold = Spherical(; radius = 6.3710088u"m")
+         unitful_cellarea = cellarea(unitful_manifold, dimz_3857)
+         @test unitful_cellarea isa Raster{<:Quantity}
+         @test Unitful.ustrip.(unitful_cellarea) == cellarea(Spherical(; radius = unitful_manifold.radius |> Unitful.ustrip), dimz_3857)
+         # Case 2: unitful dimensions
+         ux_3857 = rebuild(x_3857; val = rebuild(val(x_3857); data = val(x_3857) .* Unitful.u"m", span = Regular(val(x_3857).span.step * Unitful.u"m")))
+         uy_3857 = rebuild(y_3857; val = rebuild(val(y_3857); data = val(y_3857) .* Unitful.u"m", span = Regular(val(y_3857).span.step * Unitful.u"m")))
+         unitful_dimz_3857 = (ux_3857, uy_3857)
+         @test cellarea(Planar(), unitful_dimz_3857) isa Raster{<:Quantity}
+         @test Unitful.ustrip.(parent(cellarea(Planar(), unitful_dimz_3857))) == parent(cellarea(Planar(), dimz_3857))
+         # Unitful lookups shouldn't work without a unitful manifold
+         @test_throws Unitful.DimensionError cellarea(unitful_dimz_3857)
+         # The tests below fail because Unitful apparently can't convert to Float64...
+         # But we also have to re-convert back to the original unit type, which cellarea currently
+         # doesn't do.
+
+         # unitful_cellarea = cellarea(unitful_manifold, unitful_dimz_3857)
+         # @test unitful_cellarea isa Raster{<:Quantity}
+         # @test Unitful.ustrip.(unitful_cellarea) == cellarea(unitful_manifold, dimz_3857)
+    end
 end


### PR DESCRIPTION
Does what it says on the tin.  Unfortunately it looks like Unitful can't `convert` to Float64 (see https://github.com/PainterQubits/Unitful.jl/issues/742) so going to Proj is where this fails.

It also occurs to me that we could try to promote and rebuild e.g. bignumbers or Unitful quantities when going into `reproject`.  That would allow unitful axes to pass through reproject unchanged.