### PR TITLE
bugfix to _without_mapped_crs

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -132,7 +132,7 @@ function _without_mapped_crs(f, st::AbstractRasterStack, mappedcrs::GeoFormat)
     st1 = map(A -> setmappedcrs(A, nothing), st)
     x = f(st1)
     if x isa AbstractRasterStack
-        x = map(A -> setmappedcrs(A, mappedcrs(st)), x)
+        x = map(A -> setmappedcrs(A, mappedcrs), x)
     end
     return x
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -21,3 +21,9 @@ function temporary_random_rasters(f, N, size, type=UInt8)
         rm.(filenames; force=true)
     end
 end
+
+maybe_layers(r::AbstractRaster) = (r,)
+maybe_layers(r::AbstractRasterStack) = layers(r)
+
+identicalelements(x,y,args...) = all(x .=== y) && identicalelements(x, args...)
+identicalelements(x,y) = all(x .=== y)


### PR DESCRIPTION
just a small bugfix - mappedcrs is an actual `GeoFormat` in this case and we shouldn't try to call anything with it - or you will get this very confusing error (in my case, when calling `crop`)

```
ERROR: MethodError: objects of type EPSG{1} are not callable
The object of type `EPSG{1}` exists, but no method is defined for this combination of argument types when trying to treat it as a callable object.
```