### PR TITLE
Test `zonal` on geometries with extents that go beyond the raster

### DIFF
--- a/src/methods/burning/polygon.jl
+++ b/src/methods/burning/polygon.jl
@@ -67,11 +67,9 @@ function _set_crossings!(crossings::Vector{Float64}, edges::Edges, iy::Int, prev
     # max_ylen tells us how big the largest y edge is.
     # We can use this to jump back from the last y position
     # rather than iterating from the start of the edges
-    # TODO fix this optimisation
-    # ypos = max(1, prev_ypos - edges.max_ylen - 1)
-    # start_ypos = searchsortedlast(edges, ypos)
+    ypos = max(edges.min_y, prev_ypos - edges.max_ylen - 1)
+    start_ypos = searchsortedfirst(edges, ypos)
     # We know the maximum size on y, so we can start from ypos 
-    start_ypos = 1
     prev_ypos = start_ypos
     ncrossings = 0
     for i in start_ypos:lastindex(edges)

--- a/src/methods/burning/polygon.jl
+++ b/src/methods/burning/polygon.jl
@@ -67,11 +67,13 @@ function _set_crossings!(crossings::Vector{Float64}, edges::Edges, iy::Int, prev
     # max_ylen tells us how big the largest y edge is.
     # We can use this to jump back from the last y position
     # rather than iterating from the start of the edges
-    ypos = max(1, prev_ypos - edges.max_ylen - 1)
-    ncrossings = 0
+    # TODO fix this optimisation
+    # ypos = max(1, prev_ypos - edges.max_ylen - 1)
+    # start_ypos = searchsortedlast(edges, ypos)
     # We know the maximum size on y, so we can start from ypos 
-    start_ypos = searchsortedfirst(edges, ypos)
+    start_ypos = 1
     prev_ypos = start_ypos
+    ncrossings = 0
     for i in start_ypos:lastindex(edges)
         e = @inbounds edges[i]
         # Edges are sorted on y, so we can skip

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -224,8 +224,7 @@ end
     @testset "geometry encompassing raster" begin
         geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)])])
         raster = Raster(ones(X(1:0.1:2), Y(1:0.1:2)), missingval=false)
-        @test 
-        sum(mask(raster; with=geom)) == sum(raster)
+        @test sum(mask(raster; with=geom)) == sum(raster)
     end
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -220,6 +220,12 @@ end
             @test sum(skipmissing(mask(polytemplate; with=polygon, boundary=:touches, invert=true))) == prod(size(polytemplate)) - 21 * 21
         end
     end
+
+    @testset "geometry encompassing raster" begin
+        geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)])])
+        raster = Raster(ones(X(1:0.1:2), Y(1:0.1:2)), missingval=false)
+        @test sum(mask(raster; with=geom)) == sum(raster)
+    end
 end
 
 @testset "mask_replace_missing" begin
@@ -318,19 +324,6 @@ end
         @test zonal(sum, rast; of=polygon, skipmissing=true) isa Int
         @test !zonal(x -> x isa Raster, rast; of=polygon, skipmissing=true)
         @test zonal(x -> x isa Raster, rast; of=polygon, skipmissing=false)
-    end
-
-    @testset "geometry may be outside raster" begin
-        geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)])])
-        raster = Raster(ones(10, 10), (X(-5:4), Y(-5:4)))
-
-        @test zonal(sum, raster; of=geom) == 4 * 5 # 20 - that's the area of intersection between the raster and the polygon we defined.
-    end
-
-    @testset "geometry encompassing raster" begin
-        geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)])])
-        raster = Raster(ones(11, 11), (X(1:0.1:2), Y(1:0.1:2)))
-        @test zonal(sum, raster; of=geom) == 10 * 11 # this fails?
     end
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -224,7 +224,8 @@ end
     @testset "geometry encompassing raster" begin
         geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)])])
         raster = Raster(ones(X(1:0.1:2), Y(1:0.1:2)), missingval=false)
-        @test sum(mask(raster; with=geom)) == sum(raster)
+        @test 
+        sum(mask(raster; with=geom)) == sum(raster)
     end
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -319,6 +319,19 @@ end
         @test !zonal(x -> x isa Raster, rast; of=polygon, skipmissing=true)
         @test zonal(x -> x isa Raster, rast; of=polygon, skipmissing=false)
     end
+
+    @testset "geometry may be outside raster" begin
+        geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)])])
+        raster = Raster(ones(10, 10), (X(-5:4), Y(-5:4)))
+
+        @test zonal(sum, raster; of=geom) == 4 * 5 # 20 - that's the area of intersection between the raster and the polygon we defined.
+    end
+
+    @testset "geometry encompassing raster" begin
+        geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)] |> reverse)])
+        raster = Raster(ones(11, 11), (X(1:0.1:2), Y(1:0.1:2)))
+        @test zonal(sum, raster; of=geom) == 10 * 11 # this fails?
+    end
 end
 
 @testset "zonal return missing" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -328,7 +328,7 @@ end
     end
 
     @testset "geometry encompassing raster" begin
-        geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)] |> reverse)])
+        geom = GeoInterface.Polygon([GeoInterface.LinearRing([(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)])])
         raster = Raster(ones(11, 11), (X(1:0.1:2), Y(1:0.1:2)))
         @test zonal(sum, raster; of=geom) == 10 * 11 # this fails?
     end


### PR DESCRIPTION
We could probably degrade these tests to `rasterize`.  But IMO it's pretty important to test these edge cases.  

If these tests pass, we can enable tiled zonal on pretty much any chunk size, so you could calculate the max elevation on Greenland using a 30-meter cell size DEM like Copernicus, all on your local laptop.

This spawned #816.