### PR TITLE
construct RasterSeries from AbstractBasicDimArray

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -52,6 +52,8 @@ DD.modify(f, A::AbstractRasterSeries) = map(child -> modify(f, child), values(A)
     RasterSeries(paths::AbstractArray{<:AbstractString}, dims; child, duplicate_first, kw...)
     RasterSeries(path:::AbstractString, dims; ext, separator, child, duplicate_first, kw...)
 
+    RasterSeries(objects::AbstractBasicDimArray; kw...)
+
 Concrete implementation of [`AbstractRasterSeries`](@ref).
 
 A `RasterSeries` is an array of `Raster`s or `RasterStack`s, along some dimension(s).

--- a/src/series.jl
+++ b/src/series.jl
@@ -116,6 +116,8 @@ struct RasterSeries{T,N,D,R,A<:AbstractArray{T,N}} <: AbstractRasterSeries{T,N,D
     dims::D
     refdims::R
 end
+RasterSeries(data::DD.AbstractBasicDimArray; kw...) = 
+    RasterSeries(data, dims(data); kw...)
 function RasterSeries(data::AbstractArray{<:Union{AbstractRasterStack,AbstractRaster}}, dims;
     refdims=()
 )

--- a/test/series.jl
+++ b/test/series.jl
@@ -19,6 +19,7 @@ stack1 = RasterStack(r1, r2; name=(:r1, :r2))
 stack2 = RasterStack(r1a, r2a; name=(:r1, :r2))
 dates = [DateTime(2017), DateTime(2018)]
 ser = RasterSeries([stack1, stack2], Ti(dates))
+@test RasterSeries(DimArray([stack1, stack2],Ti(dates))) == ser
 @test issorted(dates)
 
 @testset "getindex returns the currect types" begin


### PR DESCRIPTION
Just a small quality of life improvement that makes it possible to get a `RasterSeries` from a `DimArray` using a pipe.

Things works nicely together with `@d` to make things like this possible

```julia
using Rasters, RasterDataSources
function get_climate_data(gcm, ssp)
    Raster(rand(X(1:10)))
end
ssps = [SSP370] |> Dim{:ssp}
gcms = [GFDL_ESM4, MRI_ESM2_0] |> Dim{:gcm}
(@d get_climate_data.(gcms, ssps)) |> RasterSeries |> Rasters.combine
```
which returns a `Raster` with dims `X`, `ssp`, and `gcm`