### PR TITLE
Improve performance for extract on point tables

### DIFF
--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -58,7 +58,8 @@ function extract end
    names=_names(x), name=names, skipmissing=false, geometry=true, index=false, geometrycolumn=nothing, kw...
 )
     n = DD._astuple(name)
-    _extract(x, data;
+    geoms = _get_geometries(data, geometrycolumn)
+    _extract(x, geoms;
          dims=DD.dims(x, DEFAULT_POINT_ORDER),
          names=NamedTuple{n}(n),
          # These keywords are converted to _True/_False for type stability later on
@@ -66,7 +67,6 @@ function extract end
          geometry=_booltype(geometry), 
          index=_booltype(index), 
          skipmissing=_booltype(skipmissing), 
-         geometrycolumn,
          kw...
     )
 end
@@ -78,10 +78,9 @@ end
 function _extract(A::RasterStackOrArray, geom; names, kw...)
     _extract(A, GI.geomtrait(geom), geom; names, kw...)
 end
-function _extract(A::RasterStackOrArray, ::Nothing, data; 
-    names, skipmissing, geometrycolumn, kw...
+function _extract(A::RasterStackOrArray, ::Nothing, geoms; 
+    names, skipmissing, kw...
 )
-    geoms = _get_geometries(data, geometrycolumn)
     T = _rowtype(A, eltype(geoms); names, skipmissing, kw...)
     # Handle empty / all missing cases
     (length(geoms) > 0 && any(!ismissing, geoms)) || return T[]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -211,10 +211,12 @@ function _get_geometries(data, ::Nothing)
         data
     else
         trait = GI.trait(data)
-        if GI.trait(data) isa GI.FeatureCollectionTrait
+        if trait isa GI.FeatureCollectionTrait
             [GI.geometry(f) for f in GI.getfeature(data)]
-        else
+        elseif isnothing(trait)
             collect(data)
+        else
+            data
         end
     end
     # check if data iterates valid geometries before returning
@@ -240,9 +242,10 @@ function _get_geometries(data, geometrycolumn::NTuple{<:Any, <:Symbol})
     return points
 end
 function _check_geometries(geoms)
+    !isnothing(GI.trait(geoms)) && return
     for g in geoms
-        ismissing(g) || GI.geomtrait(g) !== nothing || 
-        throw(ArgumentError("$g is not a valid GeoInterface.jl geometry"))
+        ismissing(g) || !isnothing(GI.geomtrait(g)) || 
+            throw(ArgumentError("$g is not a valid GeoInterface.jl geometry"))
     end
     return
 end


### PR DESCRIPTION
This moves `_get_geometries` to the to of the stack in extract, so performance of cases like these are much improved:

```julia
using Rasters
n = 1000000
ras = Raster(rand(X(1:2), Y(1:2)))
pointtable = (X = rand([missing, 1, 2], n), Y = rand([missing, 1, 2], n))
extract(ras, pointtable, geometrycolumn = (:X, :Y))
```