### PR TITLE
handle `FeatureTrait` and `GeometryCollectionTrait` in  `_get_geometries`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -200,6 +200,10 @@ end
 # get geometries from what may be a table with a geometrycolumn or an interable of geometries
 # if it has no geometry column and does not iterate valid geometries, error informatively
 function _get_geometries(data, ::Nothing)
+    # if GI.geometry is defined, just return that
+    geom = GI.geometry(data)
+    !isnothing(geom) && return geom
+
     # if it's a table, get the geometry column
     geoms = if !(data isa AbstractVector{<:GeoInterface.NamedTuplePoint}) && Tables.istable(data)
         geomcol = first(GI.geometrycolumns(data))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -219,10 +219,11 @@ function _get_geometries(data, ::Nothing)
             GI.geometry(data)
         elseif isnothing(trait)
             collect(data)
-        else
-            # if it has a trait but it is none of the above,
+        elseif trait isa GI.AbstractGeometryTrait
             # data is already a geometry, so return as-is
             data
+        else
+            ArgumentError("data has $trait, which is not handled")
         end
     end
     # check if data iterates valid geometries before returning


### PR DESCRIPTION
An `ArchGDAL.Feature` doesn't have a `GI.trait`, but returns its geometry with `GI.geometry`. `_get_geometries` should try that before anything else.

I'll wait for https://github.com/rafaqz/Rasters.jl/pull/852 to merge to add tests

