### PR TITLE
Allow `reproject(obj, target_crs)` as well

### DIFF
--- a/src/methods/reproject.jl
+++ b/src/methods/reproject.jl
@@ -22,7 +22,7 @@ $CRS_KEYWORD
 """
 reproject(x; crs::GeoFormat) = reproject(crs, x)
 reproject(x, target::GeoFormat) = reproject(target, x)
-reproject(::GeoFormat, ::GeoFormat) = throw(ArgumentError("You need to provide a raster object to reproject. Got two coordinate reference systems.")
+reproject(::GeoFormat, ::GeoFormat) = throw(ArgumentError("You need to provide a raster object to reproject. Got two coordinate reference systems."))
 reproject(target::GeoFormat, x) = rebuild(x; dims=reproject(target, dims(x)))
 reproject(target::GeoFormat, dims::Tuple) = map(d -> reproject(target, d), dims)
 reproject(target::GeoFormat, l::Lookup) = l

--- a/src/methods/reproject.jl
+++ b/src/methods/reproject.jl
@@ -22,6 +22,7 @@ $CRS_KEYWORD
 """
 reproject(x; crs::GeoFormat) = reproject(crs, x)
 reproject(x, target::GeoFormat) = reproject(target, x)
+reproject(::GeoFormat, ::GeoFormat) = throw(ArgumentError("You need to provide a raster object to reproject. Got two coordinate reference systems.")
 reproject(target::GeoFormat, x) = rebuild(x; dims=reproject(target, dims(x)))
 reproject(target::GeoFormat, dims::Tuple) = map(d -> reproject(target, d), dims)
 reproject(target::GeoFormat, l::Lookup) = l

--- a/src/methods/reproject.jl
+++ b/src/methods/reproject.jl
@@ -21,6 +21,7 @@ are silently returned without modification.
 $CRS_KEYWORD
 """
 reproject(x; crs::GeoFormat) = reproject(crs, x)
+reproject(x, target::GeoFormat) = reproject(target, x)
 reproject(target::GeoFormat, x) = rebuild(x; dims=reproject(target, dims(x)))
 reproject(target::GeoFormat, dims::Tuple) = map(d -> reproject(target, d), dims)
 reproject(target::GeoFormat, l::Lookup) = l

--- a/test/reproject.jl
+++ b/test/reproject.jl
@@ -24,6 +24,7 @@ using Rasters: reproject, convertlookup
     y = Y(Projected(-80.0:1.0:80.0; crs=EPSG(4326), dim=Y(), order=ReverseOrdered(), span=Regular(1.0), sampling=Intervals(Start())))
 
     x1, y1 = reproject((x, y); crs=projcea)
+    @test reproject((x, y), projcea) == reproject(projcea, (x, y))
     @test span(x1) isa Irregular
     @test span(y1) isa Irregular
     x2, y2 = reproject((x, y); crs=EPSG(4326))


### PR DESCRIPTION
Just allows a different argument order so that Rasters and GO reproject definitions are compatible
