### PR TITLE
fix extract for a single point

### DIFF
--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -285,6 +285,7 @@ end
 function _extract(A::RasterStackOrArray, e::Extractor{T}, id::Int, ::GI.PointTrait, p; kw...) where T
     rows = _init_rows(e, 1)
     _extract_point!(rows, A, e, id, p, 1; kw...)
+    return rows[1]
 end
 @noinline function _extract(
     A::RasterStackOrArray, e::Extractor{T}, id::Int, ::GI.AbstractLineStringTrait, geom;

--- a/test/extract.jl
+++ b/test/extract.jl
@@ -62,6 +62,10 @@ table = (geometry=pts, foo=zeros(4))
                 (geometry = (10.0, 0.2), test = 4)
             ]
         end
+
+        @testset "Single point" begin
+            @test extract(rast, (9.0, 0.1)) == (geometry = (9.0, 0.1), test = 1)
+        end
     end
 
     @testset "From RasterStack" begin


### PR DESCRIPTION
Adds a return statement so that `extract(ras, (x,y))` no longer returns `1` :) 