### PR TITLE
add an option to disaggregate using a view

### DIFF
--- a/src/methods/aggregate.jl
+++ b/src/methods/aggregate.jl
@@ -392,6 +392,8 @@ end
     _scale2int(x, dims, Dimensions.pairs2dims(scale...); verbose)
 @inline _scale2int(x, dims::DimTuple, scale::NamedTuple; verbose=true) = 
     _scale2int(x, dims, Dimensions.kw2dims(scale); verbose)
+@inline _scale2int(x, dims::DimTuple, scale::Dimension; verbose=true) = 
+    _scale2int(x, dims, (scale,); verbose)
 @inline function _scale2int(x, dims::DimTuple, scale::Int; verbose=true) 
     # If there are other dimensions, we skip categorical dims
     vals = map(dims) do d

--- a/src/methods/aggregate.jl
+++ b/src/methods/aggregate.jl
@@ -239,12 +239,12 @@ function disaggregate(series::AbstractRasterSeries, scale;
     return dst
 end
 function disaggregate(stack::AbstractRasterStack{K}, scale;
-    keys=keys(stack), suffix=keys, filename=nothing, progress=true, threaded=false
+    keys=keys(stack), suffix=keys, progress=true, threaded=false, kw...
 ) where K
     dst_vec = Vector{Raster}(undef, length(K))
     ls = layers(stack)
     _run(1:length(K), threaded, progress, "Disaggregating stack...") do i
-        dst_vec[i] = disaggregate(ls[i], scale; filename, suffix=suffix[i])
+        dst_vec[i] = disaggregate(ls[i], scale; suffix=suffix[i], kw...)
     end
     dst_tuple = ntuple(i -> dst_vec[i], Val{length(K)}())
     return DD.rebuild_from_arrays(stack, dst_tuple)

--- a/src/methods/aggregate.jl
+++ b/src/methods/aggregate.jl
@@ -220,7 +220,7 @@ $FILENAME_KEYWORD
 $SUFFIX_KEYWORD
 $PROGRESS_KEYWORD
 $THREADED_KEYWORD
-- `view`: Return a view of the parent array
+- `lazy`: A `Bool` specifying if to disaggregate lazily. Defaults to `false`
 
 Note: currently it is _much_ faster to disaggregate over a memory-backed 
 source array. Use [`read`](@ref) on `src` before use where required.
@@ -250,9 +250,9 @@ function disaggregate(stack::AbstractRasterStack{K}, scale;
     return DD.rebuild_from_arrays(stack, dst_tuple)
 end
 function disaggregate(src::AbstractRaster, scale;
-    suffix=nothing, filename=nothing, view = false, kw...
+    suffix=nothing, filename=nothing, lazy = false, kw...
 )
-    if view
+    if lazy
         return view_disaggregate(src, scale)
     else
         return alloc_disag(Center(), src, scale; filename, suffix, kw...) do dst

--- a/src/methods/crop_extend.jl
+++ b/src/methods/crop_extend.jl
@@ -35,7 +35,7 @@ nz_evenness = evenness[nz_bounds...]
 nz_range = crop(rnge; to=nz_evenness)
 plot(nz_range)
 
-savefig("build/nz_crop_example.png")
+savefig("build/nz_crop_example.png");
 nothing
 
 # output
@@ -144,7 +144,7 @@ sa_evenness = evenness[sa_bounds...]
 sa_range = extend(sa_evenness; to=rnge)
 plot(sa_range)
 
-savefig("build/extend_example.png")
+savefig("build/extend_example.png");
 nothing
 # output
 ```

--- a/src/methods/mosaic.jl
+++ b/src/methods/mosaic.jl
@@ -41,7 +41,7 @@ end
 scandinavia_climate = trim(mosaic(first, country_climates))
 plot(scandinavia_climate)
 
-savefig("build/mosaic_example_combined.png")
+savefig("build/mosaic_example_combined.png");
 # output
 
 ```
@@ -154,7 +154,7 @@ scandinavia_climate = mosaic(first, country_climates)
 # And plot
 plot(scandinavia_climate)
 
-savefig("build/mosaic_bang_example.png")
+savefig("build/mosaic_bang_example.png");
 # output
 
 ```

--- a/test/aggregate.jl
+++ b/test/aggregate.jl
@@ -217,3 +217,9 @@ end
     @test_throws ArgumentError aggregate(sum, rast[X=1, Y=1], 2)
 end
 
+@test "Lazy disaggregation" begin
+    eager_disag = disaggregate(array1, (X(2), Y(2))) 
+    lazy_disag = disaggregate(array1, (X(2), Y(2)); view = true)
+    @test eager_disag == lazy_disag
+    @test parent(lazy_disag) isa SubArray
+end

--- a/test/aggregate.jl
+++ b/test/aggregate.jl
@@ -168,6 +168,7 @@ end
         aggregate(sum, array1, (Y=2, X=3)) == 
         aggregate(sum, array1, (Y=>2, X=>3)) == 
         aggregate(sum, array1, (:Y=>2, :X=>3)) == 
+        aggregate(sum, aggregate(sum, array1, Y(2)), X(3)) ==
         [45 57 69]
 end
 

--- a/test/aggregate.jl
+++ b/test/aggregate.jl
@@ -218,7 +218,7 @@ end
     @test_throws ArgumentError aggregate(sum, rast[X=1, Y=1], 2)
 end
 
-@test "Lazy disaggregation" begin
+@testset "Lazy disaggregation" begin
     eager_disag = disaggregate(array1, (X(2), Y(2))) 
     lazy_disag = disaggregate(array1, (X(2), Y(2)); view = true)
     @test eager_disag == lazy_disag

--- a/test/aggregate.jl
+++ b/test/aggregate.jl
@@ -220,7 +220,17 @@ end
 
 @testset "Lazy disaggregation" begin
     eager_disag = disaggregate(array1, (X(2), Y(2))) 
-    lazy_disag = disaggregate(array1, (X(2), Y(2)); view = true)
+    lazy_disag = disaggregate(array1, (X(2), Y(2)); lazy = true)
     @test eager_disag == lazy_disag
     @test parent(lazy_disag) isa SubArray
+
+    eager_disag_stack = disaggregate(stack1, 2)
+    lazy_disag_stack = disaggregate(stack1, 2; lazy = true)
+    @test eager_disag_stack == lazy_disag_stack
+    @test all(x -> x isa SubArray, parent(lazy_disag_stack))
+
+    eager_disag_series = disaggregate(series, 2)
+    lazy_disag_series = disaggregate(series, 2; lazy = true)
+    @test eager_disag_series == lazy_disag_series
+    @test all(x -> all(x -> x isa SubArray, parent(x)), lazy_disag_series)
 end


### PR DESCRIPTION
This adds a `view` keyword option to `disaggregate`, in which case it just returns a view instead of eagerly extracting the values and allocating a new array.

I think it's worth adding as it's just a few lines of code and minimal feature creep, just one keyword, and whenever memory is an issue this is kind of neat.

We could consider a lazy aggregation as well, though it wouldn't be quite as easy.