### PR TITLE
Cdm backendexception

### DIFF
--- a/src/sources/commondatamodel.jl
+++ b/src/sources/commondatamodel.jl
@@ -38,7 +38,8 @@ sourcetrait(var::CDM.CFVariable) = sourcetrait(var.var)
 # Dataset constructor from `Source`
 sourceconstructor(source::Source) = sourceconstructor(typeof(source))
 # Function to check filename
-function checkfilename end
+checkfilename(s::CDMsource, filename) = throw(BackendException(s))
+
 # Find and check write modes
 function checkwritemode(::CDMsource, filename, append::Bool, force::Bool)
     if append
@@ -54,7 +55,7 @@ openmode(write::Bool) = write ? "a" : "r"
 missingval(var::CDM.AbstractVariable, md::Metadata{<:CDMsource}) =
     missingval(md)
 missingval(var::CDM.AbstractVariable, args...) = 
-    missingval(Metadata{soucetrait(var)}(CDM.attribs(var)))
+    missingval(Metadata{sourcetrait(var)}(CDM.attribs(var)))
 
 @inline function get_scale(metadata::Metadata{<:CDMsource}, scaled::Bool)
     scale = scaled ? get(metadata, "scale_factor", nothing) : nothing

--- a/src/sources/sources.jl
+++ b/src/sources/sources.jl
@@ -55,6 +55,7 @@ const EXT2SOURCE = Dict(
 struct BackendException <: Exception
     backend
 end
+BackendException(s::Source) = BackendException(SOURCE2PACKAGENAME[s])
 
 # error message to show when backend is not loaded
 function Base.showerror(io::IO, e::BackendException)
@@ -100,7 +101,4 @@ end
 function _open(f, filename::AbstractString; source=sourcetrait(filename), kw...)
     _open(f, source, filename; kw...)
 end
-function _open(f, s::Source, filename::AbstractString; kw...)
-    packagename = SOURCE2PACKAGENAME[s]
-    throw(BackendException(packagename))
-end
+_open(f, s::Source, filename::AbstractString; kw...) = throw(BackendException(s))

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -4,6 +4,11 @@ using Test, Rasters
 @test_throws Rasters.BackendException resample(1, 2, 3)
 @test_throws Rasters.BackendException warp(1, 2, 3)
 
+@test_throws "import ZarrDatasets" Raster("notafile.zarr")
+@test_throws "import ArchGDAL" Raster("notafile.tif")
+@test_throws "import NCDatasets" Raster("notafile.nc")
+@test_throws "import GRIBDatasets" Raster("notafile.grib")
+
 import ArchGDAL
 
 # Should throw a MethodError now that ArchGDAL is loaded

--- a/test/sources/sources.jl
+++ b/test/sources/sources.jl
@@ -70,8 +70,3 @@ using Rasters: sourcetrait
 @test sourcetrait(Rasters.GRIBsource) == Rasters.GRIBsource()
 @test sourcetrait(Rasters.GDALsource) == Rasters.GDALsource()
 @test sourcetrait(Rasters.Zarrsource) == Rasters.Zarrsource()
-
-@test_throws "import ZarrDatasets" Raster("notafile.zarr")
-@test_throws "import ArchGDAL" Raster("notafile.tif")
-@test_throws "import NCDatasets" Raster("notafile.nc")
-@test_throws "import GRIBDatasets" Raster("notafile.grib")

--- a/test/sources/sources.jl
+++ b/test/sources/sources.jl
@@ -70,3 +70,8 @@ using Rasters: sourcetrait
 @test sourcetrait(Rasters.GRIBsource) == Rasters.GRIBsource()
 @test sourcetrait(Rasters.GDALsource) == Rasters.GDALsource()
 @test sourcetrait(Rasters.Zarrsource) == Rasters.Zarrsource()
+
+@test_throws "import ZarrDatasets" Raster("notafile.zarr")
+@test_throws "import ArchGDAL" Raster("notafile.tif")
+@test_throws "import NCDatasets" Raster("notafile.nc")
+@test_throws "import GRIBDatasets" Raster("notafile.grib")


### PR DESCRIPTION
On main `using Rasters; Raster("myraster.nc")` returns `ERROR: MethodError: no method matching checkfilename(::Rasters.NCDsource, ::String)`. I think the backendexception that is intended here was broken with the introduction of CDM?

