### PR TITLE
use vectors rather than tuples in mosaic for scaling properties

### DIFF
--- a/src/create.jl
+++ b/src/create.jl
@@ -347,10 +347,9 @@ function create(filename::AbstractString, source::Source, layertypes::NamedTuple
     fn = Rasters.write(filename, st1;
         chunks, metadata, scale, offset, missingval=mv_inner, verbose, force, coerce, write, kw...
     ) do W
-        # write returns a variable, wrap it as a RasterStack
-        f(rebuild(st1; data=W))
+        f(rebuild(st1; data=W)) # write returns a variable, wrap it as a RasterStack
     end
-    st2 = RasterStack(fn; source, lazy, metadata, layerdims, dropband, coerce, missingval=mv_outer)
+    st2 = RasterStack(fn; source, lazy, metadata, dropband, coerce, missingval=mv_outer)
     return st2
 end
 

--- a/src/methods/mosaic.jl
+++ b/src/methods/mosaic.jl
@@ -226,7 +226,7 @@ end
 # Where there is a known reduction operator we can apply each region as a whole
 function _mosaic!(
     f::Function, op, dest::AbstractRaster, regions::RasterVecOrTuple; 
-    gc::Union{Integer,Nothing}=50,
+    gc::Union{Integer,Nothing}=nothing,
     progress=true,
     _progressmeter=_mosaic_progress(f, progress, length(regions)),
     kw...

--- a/src/sources/commondatamodel.jl
+++ b/src/sources/commondatamodel.jl
@@ -492,6 +492,7 @@ end
 function Base.write(filename::AbstractString, source::Source, s::AbstractRasterStack{K,T};
     append=false,
     force=false,
+    write=true,
     missingval=nokw,
     f=identity,
     kw...
@@ -501,9 +502,9 @@ function Base.write(filename::AbstractString, source::Source, s::AbstractRasterS
     missingval = _stack_nt(s, isnokw(missingval) ? Rasters.missingval(s) : missingval)
     try
         map(keys(s)) do k
-            writevar!(ds, source, s[k]; missingval=missingval[k], kw...)
+            writevar!(ds, source, s[k]; missingval=missingval[k], write, kw...)
         end
-        f(OpenStack{Source,K,T}(ds))
+        write && f(OpenStack{Source,K,T}(ds))
     finally
         close(ds)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -601,3 +601,15 @@ _rowkeys(id::_False, geometry::_False, index::_False, names::NamedTuple{Names}) 
 _rowkeys(id::_False, geometry::_True, index::_False, names::NamedTuple{Names}) where Names = (:geometry, Names...)
 _rowkeys(id::_False, geometry::_True, index::_True, names::NamedTuple{Names}) where Names = (:geometry, :index, Names...)
 _rowkeys(id::_False, geometry::_False, index::_True, names::NamedTuple{Names}) where Names = (:index, Names...)
+
+_stack_nt(::NamedTuple{K}, x) where K = NamedTuple{K}(map(_ -> x, K))
+_stack_nt(::RasterStack{<:Any,T}, x) where T = _stack_nt(T, x)
+_stack_nt(::Type{T}, x::NamedTuple{K}) where {K,T<:NamedTuple{K}} = x
+_stack_nt(::Type{T}, x::NamedTuple{K1}) where {K1,T<:NamedTuple{K2}} where K2 =
+    throw(ArgumentError("stack keys $K1 do not match misssingval keys $K2"))
+_stack_nt(::Type{T}, x) where T<:NamedTuple{K} where K =
+    NamedTuple{K}(map(_ -> x, K))
+
+@generated function _types(::Type{<:NamedTuple{K,T}}) where {K,T}
+    Tuple(T.parameters)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,6 +94,12 @@ function _writeable_missing(T; verbose=true)
 end
 
 _type_missingval(::Type{T}) where T = _type_missingval1(Missings.nonmissingtype(T))
+@generated function _type_missingval(::Type{NT}) where NT<:NamedTuple{K,T} where {K,T}
+    mvs = map(T.parameters) do Tn
+        _type_missingval1(Missings.nonmissingtype(Tn))
+    end
+    return :(NamedTuple{K}($mvs))
+end
 
 _type_missingval1(::Type{T}) where T<:Number = typemin(T)
 _type_missingval1(::Type{T}) where T<:Unsigned = typemax(T)

--- a/src/write.jl
+++ b/src/write.jl
@@ -109,7 +109,7 @@ function Base.write(path::AbstractString, s::AbstractRasterStack{K};
     source = sourcetrait(source)
     missingval = _stack_missingvals(s, missingval)
     if haslayers(source)
-        write(path, source, s; missingval, kw...)
+        write(path, source, s; missingval, f, kw...)
     else
         # Otherwise write separate files for each layer
         if isnothing(ext)
@@ -150,23 +150,11 @@ function _stack_missingvals(::Type{T}, missingval::NamedTuple{K}) where {K,T<:Na
     end |> NamedTuple{K}
 end
 _stack_missingvals(::Type{T}, missingval::NamedTuple{K1}) where {K1,T<:NamedTuple{K2}} where K2 =
-    throw(ArgumentError("stack keys $K1 do not match misssingval keys $K2"))
+    throw(ArgumentError("stack keys $K1 do not match missingval keys $K2"))
 _stack_missingvals(::Type{T}, missingval::Missing) where T<:NamedTuple{K} where K =
     NamedTuple{K}(map(_type_missingval, _types(T)))
 _stack_missingvals(::Type{T}, missingval) where T =
     _stack_nt(T, missingval)
-
-_stack_nt(::NamedTuple{K}, x) where K = NamedTuple{K}(map(_ -> x, K))
-_stack_nt(::RasterStack{<:Any,T}, x) where T = _stack_nt(T, x)
-_stack_nt(::Type{T}, x::NamedTuple{K}) where {K,T<:NamedTuple{K}} = x
-_stack_nt(::Type{T}, x::NamedTuple{K1}) where {K1,T<:NamedTuple{K2}} where K2 =
-    throw(ArgumentError("stack keys $K1 do not match misssingval keys $K2"))
-_stack_nt(::Type{T}, x) where T<:NamedTuple{K} where K =
-    NamedTuple{K}(map(_ -> x, K))
-
-@generated function _types(::Type{<:NamedTuple{K,T}}) where {K,T}
-    Tuple(T.parameters)
-end
 
 """
     Base.write(filepath::AbstractString, s::AbstractRasterSeries; kw...)

--- a/test/mosaic.jl
+++ b/test/mosaic.jl
@@ -1,67 +1,74 @@
 using Rasters, Dates, Statistics, Test
 using Rasters.Lookups, Rasters.Dimensions 
 
-@testset "mosaic" begin
-    reg1 = Raster([0.1 0.2; 0.3 0.4], (X(2.0:1.0:3.0), Y(5.0:1.0:6.0)))
-    reg2 = Raster([1.1 1.2; 1.3 1.4], (X(3.0:1.0:4.0), Y(6.0:1.0:7.0)))
-    irreg1 = Raster([0.1 0.2; 0.3 0.4], (X([2.0, 3.0]), Y([5.0, 6.0])))
-    irreg2 = Raster([1.1 1.2; 1.3 1.4], (X([3.0, 4.0]), Y([6.0, 7.0])))
+reg1 = Raster([0.1 0.2; 0.3 0.4], (X(2.0:1.0:3.0), Y(5.0:1.0:6.0)))
+reg2 = Raster([1.1 1.2; 1.3 1.4], (X(3.0:1.0:4.0), Y(6.0:1.0:7.0)))
+irreg1 = Raster([0.1 0.2; 0.3 0.4], (X([2.0, 3.0]), Y([5.0, 6.0])))
+irreg2 = Raster([1.1 1.2; 1.3 1.4], (X([3.0, 4.0]), Y([6.0, 7.0])))
 
-    span_x1 = Explicit(vcat((1.5:1.0:2.5)', (2.5:1.0:3.5)'))
-    span_x2 = Explicit(vcat((2.5:1.0:3.5)', (3.5:1.0:4.5)'))
-    exp1 = Raster([0.1 0.2; 0.3 0.4], (X(Sampled([2.0, 3.0]; span=span_x1)), Y([5.0, 6.0])))
-    exp2 = Raster([1.1 1.2; 1.3 1.4], (X(Sampled([3.0, 4.0]; span=span_x2)), Y([6.0, 7.0])))
+span_x1 = Explicit(vcat((1.5:1.0:2.5)', (2.5:1.0:3.5)'))
+span_x2 = Explicit(vcat((2.5:1.0:3.5)', (3.5:1.0:4.5)'))
+exp1 = Raster([0.1 0.2; 0.3 0.4], (X(Sampled([2.0, 3.0]; span=span_x1)), Y([5.0, 6.0])))
+exp2 = Raster([1.1 1.2; 1.3 1.4], (X(Sampled([3.0, 4.0]; span=span_x2)), Y([6.0, 7.0])))
+
+@testset "first and last" begin
     @test val(span(mosaic(first, exp1, exp2), X)) == [1.5 2.5 3.5; 2.5 3.5 4.5]
     @test all(mosaic(first, [reg1, reg2]) .=== 
-              mosaic(first, irreg1, irreg2) .===
-              mosaic(first, (irreg1, irreg2)) .=== 
-              [0.1 0.2 missing; 
-               0.3 0.4 1.2; 
-               missing 1.3 1.4])
+                mosaic(first, irreg1, irreg2) .===
+                mosaic(first, (irreg1, irreg2)) .=== 
+                [0.1 0.2 missing; 
+                0.3 0.4 1.2; 
+                missing 1.3 1.4])
     @test all(mosaic(last, reg1, reg2) .===
-              mosaic(last, irreg1, irreg2) .===
-              mosaic(last, exp1, exp2) .=== [0.1 0.2 missing; 
-                                             0.3 1.1 1.2; 
-                                             missing 1.3 1.4])
+                mosaic(last, irreg1, irreg2) .===
+                mosaic(last, exp1, exp2) .=== [0.1 0.2 missing; 
+                                                0.3 1.1 1.2; 
+                                                missing 1.3 1.4])
 
     @test all(mosaic(first, [reverse(reg2; dims=Y), reverse(reg1; dims=Y)]) .=== 
         [missing 0.2 0.1; 
-         1.2 1.1 0.3; 
-         1.4 1.3 missing]
+            1.2 1.1 0.3; 
+            1.4 1.3 missing]
     )
-            
-    @testset "Generic functions" begin
-        @test all(mosaic(xs -> count(x -> x > 0, xs), reg1, reg2) .===
-            [1 1 missing
-             1 2 1 
-             missing 1 1]
-        )
-    end
+end
+        
+@testset "Generic functions" begin
+    @test all(mosaic(xs -> count(x -> x > 0, xs), reg1, reg2) .===
+        [1 1 missing
+            1 2 1 
+            missing 1 1]
+    )
+end
 
-    @testset "3 dimensions" begin
-        A1 = Raster(ones(2, 2, 2), (X(2.0:-1.0:1.0), Y(5.0:1.0:6.0), Ti(DateTime(2001):Year(1):DateTime(2002))))
-        A2 = Raster(zeros(2, 2, 2), (X(3.0:-1.0:2.0), Y(4.0:1.0:5.0), Ti(DateTime(2002):Year(1):DateTime(2003))))
-        mean_mos = cat([missing missing missing
-                    missing 1.0     1.0
-                    missing 1.0     1.0    ],
-                    [0.0     0.0 missing
-                    0.0     0.5     1.0   
-                    missing 1.0     1.0    ],
-                    [0.0     0.0     missing
-                    0.0     0.0     missing    
-                    missing missing missing], dims=3)
-        @test all(mosaic(mean, A1, A2) .=== 
-                mosaic(mean, RasterStack(A1), RasterStack(A2)).layer1 .===
-                mean_mos)
-        @test mosaic(length, A1, A2; missingval=0) == cat([0 0 0
-            0 1 1
-            0 1 1],
-            [1 1 0
-            1 2 1
-            0 1 1], 
-            [1 1 0
-            1 1 0
-            0 0 0], dims=3)
-    end
+@testset "3 dimensions" begin
+    A1 = Raster(ones(2, 2, 2), (X(2.0:-1.0:1.0), Y(5.0:1.0:6.0), Ti(DateTime(2001):Year(1):DateTime(2002))))
+    A2 = Raster(zeros(2, 2, 2), (X(3.0:-1.0:2.0), Y(4.0:1.0:5.0), Ti(DateTime(2002):Year(1):DateTime(2003))))
+    mean_mos = cat([missing missing missing
+                missing 1.0     1.0
+                missing 1.0     1.0    ],
+                [0.0     0.0 missing
+                0.0     0.5     1.0   
+                missing 1.0     1.0    ],
+                [0.0     0.0     missing
+                0.0     0.0     missing    
+                missing missing missing], dims=3)
+    @test all(mosaic(mean, A1, A2) .=== 
+            mosaic(mean, RasterStack(A1), RasterStack(A2)).layer1 .===
+            mean_mos)
+    @test mosaic(length, A1, A2; missingval=0) == cat([0 0 0
+        0 1 1
+        0 1 1],
+        [1 1 0
+        1 2 1
+        0 1 1], 
+        [1 1 0
+        1 1 0
+        0 0 0], dims=3)
+end
 
+@testset "many regions" begin
+    # Test that `mosaic` can scale up to handle many inputs
+    regions = [reg1 for _ in 1:10000]
+    # These should be identical
+    @test all(isapprox.(mosaic(sum, regions), sum(regions)))
 end


### PR DESCRIPTION
Running `mosaic` over thousands of Rasters doesn't really work currently, due to splatting and using Tuples.

This PR switches everything to use vectors of rasters/dims/lookups. This should be type stable where all rasters are identical, and not where they are not. But it seems to work for arbitrary amounts of rasters after this