### PR TITLE
Fix `extend` for reverse ordered lookups

### DIFF
--- a/src/methods/crop_extend.jl
+++ b/src/methods/crop_extend.jl
@@ -253,8 +253,8 @@ function _extend_to(x::RasterStackOrArray, extent::Extents.Extent{K}; kw...) whe
         fl = LA.ordered_first(l); ll = LA.ordered_last(l)
         fb = first(b); lb = last(b)
         s = step(l)
-        lowerrange = fb < first(bounds(l)) ? (fl:-s:fb) : (fl:-s:fl)
-        upperrange = lb > last(bounds(l))  ? (ll: s:lb) : (ll: s:ll)
+        lowerrange = fb < first(bounds(l)) ? (fl:copysign(s, -1):fb) : (fl:copysign(s, -1):fl)
+        upperrange = lb > last(bounds(l))  ? (ll:copysign(s, 1):lb) : (ll:copysign(s, 1):ll)
         if DD.order(l) isa ForwardOrdered
             newrange = last(lowerrange):s:last(upperrange)
         elseif order(d) isa ReverseOrdered
@@ -263,6 +263,7 @@ function _extend_to(x::RasterStackOrArray, extent::Extents.Extent{K}; kw...) whe
         newlookup = rebuild(l; data=newrange)
         rebuild(d, newlookup)
     end
+    @show newdims
     return _extend_to(x, newdims; kw...)
 end
 

--- a/src/methods/crop_extend.jl
+++ b/src/methods/crop_extend.jl
@@ -263,7 +263,6 @@ function _extend_to(x::RasterStackOrArray, extent::Extents.Extent{K}; kw...) whe
         newlookup = rebuild(l; data=newrange)
         rebuild(d, newlookup)
     end
-    @show newdims
     return _extend_to(x, newdims; kw...)
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -413,19 +413,20 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
 
 @testset "trim, crop, extend" begin
     A = [missing missing missing
+        missing missing missing
          missing 2.0     0.5
          missing 1.0     missing]
 
-    r_fwd = Raster(A, (X(1.0:1.0:3.0), Y(1.0:1.0:3.0)); missingval=missing)
-    r_crs = Raster(A, (X(1.0:1.0:3.0), Y(1.0:1.0:3.0)); missingval=missing, crs = EPSG(4326))
-    r_mcrs = Raster(A, (X(1.0:1.0:3.0), Y(1.0:1.0:3.0)); missingval=missing, crs = EPSG(4326), mappedcrs = EPSG(4326))
+    r_fwd = Raster(A, (X(1.0:1.0:4.0), Y(1.0:1.0:3.0)); missingval=missing)
+    r_crs = Raster(A, (X(1.0:1.0:4.0), Y(1.0:1.0:3.0)); missingval=missing, crs = EPSG(4326))
+    r_mcrs = Raster(A, (X(1.0:1.0:4.0), Y(1.0:1.0:3.0)); missingval=missing, crs = EPSG(4326), mappedcrs = EPSG(4326))
     r_revX = reverse(r_fwd; dims=X)
     r_revY = reverse(r_fwd; dims=Y)
     st1 = RasterStack((a = r_fwd, b = r_fwd))
     st2 = RasterStack((a = r_fwd, b = r_fwd), crs = EPSG(4326))
     st3 = RasterStack((a = r_fwd, b = r_fwd), crs = EPSG(4326), mappedcrs = EPSG(4326))
 
-    ga = r_fwd
+    ga = r_revX
     for ga in (r_fwd, r_crs, r_mcrs, r_revX, r_revY, st1, st2, st3)
         # Test with missing on all sides
         ga_r = rot180(ga)
@@ -447,6 +448,8 @@ createpoint(args...) = ArchGDAL.createpoint(args...)
         extended1 = extend(extend(cropped; to=dims(ga, X)); to=dims(ga, Y))
         filename = tempname() * ".tif"
         extended_d = extend(cropped; to=ga, filename)
+        @test dims(extended) == dims(extended1) == dims(extended_d) == dims(ga)
+        @test dims(extended_r) == dims(ga_r)
         @test map(identicalelements, maybe_layers.((extended, extended1, replace_missing(extended_d), ga))...) |> all
         @test map(identicalelements, maybe_layers.((extended_r, ga_r))...) |> all
         @test all(map(==, lookup(extended_d), lookup(extended)))


### PR DESCRIPTION
We needed a `copysign` internally instead of a minus sign.

Because of how ranges work `extend` before this PR just extended a single step, which happened to be the only thing we tested for.