### PR TITLE
fix offset handling in extract

### DIFF
--- a/test/extract.jl
+++ b/test/extract.jl
@@ -411,7 +411,7 @@ end
 
 # to make sure all the offset handling works
 @testset "Extract from a big Raster" begin
-    extend(rast; to = Extent(X = (8, 100), Y = (-1, 1)))
+    bigrast = extend(rast; to = Extent(X = (8, 100), Y = (-1, 1)))
     for geom in (poly, line, pts, table) # linestring is currently broken
         @test extract(bigrast, geom, skipmissing = true) == extract(rast, geom, skipmissing = true)
         @test filter(nt -> !ismissing(nt.test), extract(bigrast, geom)) == extract(rast, geom, skipmissing = true)

--- a/test/extract.jl
+++ b/test/extract.jl
@@ -409,6 +409,15 @@ end
     @test all(getfield.(extr, :dimpoints) .== vec(ras))
 end
 
+# to make sure all the offset handling works
+@testset "Extract from a big Raster" begin
+    extend(rast; to = Extent(X = (8, 100), Y = (-1, 1)))
+    for geom in (poly, line, pts, table) # linestring is currently broken
+        @test extract(bigrast, geom, skipmissing = true) == extract(rast, geom, skipmissing = true)
+        @test filter(nt -> !ismissing(nt.test), extract(bigrast, geom)) == extract(rast, geom, skipmissing = true)
+    end
+end
+
 #=
 Some benchmark and plotting code
 


### PR DESCRIPTION
Fixes 2 issues in extract:
- for linestring, the resize! just resized to the maximum length of the latest line segment, instead of the total - triggering out of bounds indexing errors
- for line and polygon burning, offset wasn't applied in `_prop_nt`, meaning the wrong values got extracted! I hope this got introduced by https://github.com/rafaqz/Rasters.jl/pull/911/, but I'm not sure. It evaded tests because we test on 2x2 rasters where the offset is always 0