### PR TITLE
fix size checks for non isbits and RasterStack

### DIFF
--- a/src/stack.jl
+++ b/src/stack.jl
@@ -519,7 +519,7 @@ function _layer_stack(filename;
     mappedcrs=nokw,
     coerce=convert,
     scaled=nokw,
-    checkmem=true,
+    checkmem=CHECKMEM[],
     lazy=false,
     kw...
 )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -398,7 +398,14 @@ _checkobjmem(f, obj) = _checkmem(f, _sizeof(obj))
 
 _checkmem(f, bytes::Int) = Sys.free_memory() > bytes || _no_memory_error(f, bytes)
 
-_sizeof(A::AbstractArray{T}) where T = sizeof(T) * prod(size(A))
+function _sizeof(A::AbstractArray{T}) where T 
+    if isbits(T)
+        sizeof(T) * prod(size(A))
+    else
+        # We just guess the size if not isbits. Probably an underestimate.
+        sizeof(Int) * prod(size(A))
+    end
+end
 _sizeof(st::AbstractRasterStack) = sum(_sizeof, layers(st))
 _sizeof(s::AbstractRasterSeries) =
     length(s) == 0 ? 0 : _sizeof(first(s)) * prod(size(s))

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -420,6 +420,13 @@ end
         ncarray[Y(100), Ti(1)] |> plot
     end
 
+    @testset "read and write String" begin
+        rast = Raster(fill("x", X(1:10), Y(1:10)))
+        filename = tempname() * ".nc"
+        write(filename, rast)
+        @test Raster(filename) == rast
+    end
+
 end
 
 @testset "Single file stack" begin


### PR DESCRIPTION
Allow skipping size checks for RasterStack, and do fake sizechecks for non-isbits like String, `sizeof` fails