### PR TITLE
Zonal improvements without geometry lookup

### DIFF
--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -18,3 +18,29 @@ mean(A; dims=Band)
 ```
 """
 @dim Band
+
+
+"""
+    Geometry <: Dimension
+    Geometry(geoms)
+
+Geometry [`Dimension`]($DDdimdocs) for vector data cubes.
+
+"""
+@dim Geometry
+
+
+# Below is the example docstring for the Geometry dimension, which should be added back to the docs
+# when geometry lookups are fully implemented.
+#=
+## Example
+```julia
+geomdim = Geometry(GeometryLookup(polygons))
+# Or
+val = A[Geometry(1)]
+# Or
+val = A[Geometry(Touches(other_geom))] # this is automatically accelerated by spatial trees!
+# Or
+mean(A; dims=Geometry)
+```
+=#

--- a/src/methods/zonal.jl
+++ b/src/methods/zonal.jl
@@ -202,7 +202,7 @@ function _zonal(f, x::RasterStackOrArray, ::Nothing, data;
             end
         )
         return rebuild(x; data = dimarrays, dims = (dims(first(zs))..., return_dimension))
-    elseif zs isa AbstractVector{<: NamedTuple{names(x)}} && !isfalse(spatialslices)
+    elseif x isa RasterStack &&zs isa AbstractVector{<: NamedTuple{names(x)}} && !isfalse(spatialslices)
         # if we just have a vector of named tuple -> value: do not dimensionalize,
         # so that this is not breaking.
         if !any(p -> p isa AbstractDimArray, values(first(zs)))
@@ -404,6 +404,8 @@ function _cat_and_rebuild_parent(parent::AbstractDimStack, children, newdim)
         Base.size(A::GetpropertyArray) = size(A.data)
         Base.ndims(A::GetpropertyArray) = ndims(A.data)
         =#
+        # and then we wrap all the layers in this struct.  Granted, this does increase the amount of time for getindex by
+        # an instruction or so.
         layer_rasters = map(names(parent)) do name
             layer_children = map(child -> getproperty.(child, (name,)), children)
             backing_array = __do_cat_with_last_dim(layer_children) # see zonal.jl for implementation

--- a/src/methods/zonal.jl
+++ b/src/methods/zonal.jl
@@ -216,7 +216,6 @@ function _zonal(f, x::RasterStackOrArray, ::Nothing, data;
         _spdims = istrue(spatialslices) ? (Val{DD.XDim}(), Val{DD.YDim}()) : spatialslices
         _odims = DD.otherdims(dims(x), _spdims)
         r = RasterStack(NamedTuple{names(x)}(layers), (_odims..., return_dimension); crs = crs(x), refdims = (), metadata = metadata(x), missingval = missingval)
-        Main.@infiltrate
         return r
     end
     return zs
@@ -295,7 +294,6 @@ function _zonal_via_map(f, x, geoms; progress, threaded, missingval, bylayer, sp
             isnothing(p) || ProgressMeter.next!(p)
             a
         end
-        Main.@infiltrate
         return res
     end
 end

--- a/src/methods/zonal.jl
+++ b/src/methods/zonal.jl
@@ -218,9 +218,7 @@ function _zonal(f, x::RasterStackOrArray, ::Nothing, data;
             end
         end
 
-        _spdims = istrue(spatialslices) ? (Val{DD.XDim}(), Val{DD.YDim}()) : spatialslices
-        _odims = DD.otherdims(dims(x), _spdims)
-        r = RasterStack(NamedTuple{names(x)}(layers), (_odims..., return_dimension); crs = crs(x), refdims = (), metadata = metadata(x), missingval = missingval)
+        r = RasterStack(NamedTuple{names(x)}(layers); crs = crs(x), refdims = (), metadata = metadata(x), missingval = missingval)
         return r
     end
     return zs
@@ -286,7 +284,9 @@ function _zonal_via_map(f, x, geoms; progress, threaded, missingval, bylayer, sp
             # Spawn a task to process this chunk
             GeometryOpsCore.StableTasks.@spawn begin
                 # Where we map `f` over the chunk indices
-                r = map(f, chunk)
+                r = map($chunk) do i
+                    _zonal(f, x, (geoms)[i]; missingval, bylayer, spatialslices, (kw)...)
+                end
                 isnothing(p) || ProgressMeter.next!(p; step = length(chunk))
                 r
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -553,6 +553,13 @@ istrue(::_True) = true
 istrue(::_False) = false
 istrue(::Type{_True}) = true
 istrue(::Type{_False}) = false
+istrue(x) = x == true
+
+isfalse(::_True) = false
+isfalse(::_False) = true
+isfalse(::Type{_True}) = false
+isfalse(::Type{_False}) = true
+isfalse(x) = x == false
 
 # skipinvalid: can G and I be missing. skipmissing: can nametypes be missing
 _rowtype(x, g, args...; kw...) = _rowtype(x, typeof(g), args...; kw...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -553,12 +553,16 @@ istrue(::_True) = true
 istrue(::_False) = false
 istrue(::Type{_True}) = true
 istrue(::Type{_False}) = false
+istrue(::Val{v}) where v = istrue(v)
+
 istrue(x) = x == true
 
 isfalse(::_True) = false
 isfalse(::_False) = true
 isfalse(::Type{_True}) = false
 isfalse(::Type{_False}) = true
+isfalse(::Val{v}) where v = isfalse(v)
+
 isfalse(x) = x == false
 
 # skipinvalid: can G and I be missing. skipmissing: can nametypes be missing

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -32,3 +32,16 @@ end
     @test _chunks_to_tuple(template, (X(), Y(), Ti()), (Y(8), X(12))) == (12, 8, 1)
     @test _chunks_to_tuple(template, (Ti(), X(), Y()), (Y(8), X(12))) == (1, 12, 8)
 end
+
+@testset "booltypes" begin
+    @test istrue(_True())
+    @test istrue(true)
+    @test istrue(_True())
+
+    @test isfalse(_False())
+    @test isfalse(false)
+    @test isfalse(_False())
+
+    @test !istrue(10)
+    @test !isfalse(10)
+end


### PR DESCRIPTION
- `spatialslices = false`: if true, run `f` on the slices of the datacube in `X, Y`.  You can also pass a tuple of dimensions to specify which dims to slice over.  If false, run zonal on the whole cube cropped to each geom.  If spatialslices is not false, then a data cube will be returned, with a `Geometry(1:ngeom)` axis.
- `bylayer = true`: if true, run `f` on each layer of the stack individually, then recombine results into a `NamedTuple`.  If false, then run `f` on the whole stack.
- `missingval = missingval(x)`: specify the missing value that is to be pushed into the resulting raster.

### Explanatory script
```julia
using Rasters, RasterDataSources, ArchGDAL
using NaturalEarth
import Proj

precip = cat((Raster(WorldClim{Climate}, :prec; month = i) for i in 1:12)...; dims = Ti)
all_countries = naturalearth("admin_0_countries", 10)

precip_cellarea_stack = RasterStack((; precip = precip, cellarea = cellarea(precip)))

# First, we have standard zonal.  This returns what it always used to return.
function f(ras)
    sum(ras)
end

@time zonal(f, precip_cellarea_stack[Ti(1)]; of = all_countries, skipmissing = true, threaded = false)

# Then, we have zonal with `bylayer = false`.  This gives the zonal function the entire stack,
# which means that it can operate on all layers of the stack at once.  This allows you to e.g.
# compute statistics which require the values of multiple layers, simultaneously.
# TODO: for best use, this still needs a good implementation of skipmissing on stacks.
function f(stack)
    isempty(stack) || all(ismissing, stack.precip) && return missing
    prec_net = sum(skipmissing(stack.precip .* stack.cellarea))
    avg_precip = prec_net ./ sum(skipmissing(stack.cellarea))
    return avg_precip
end

@time zonal(f, precip_cellarea_stack[Ti(1)]; of = all_countries, bylayer = false, skipmissing = false, threaded = false)

# Next, we have `spatialslices = true`.  This allows you to pass a data cube (not just a 2d raster),
# and have zonal automatically slice the cube into 2D (X, Y) slices, such that your function only needs 
# to know how to operate on 2D slices.
zonal(f, precip_cellarea_stack; of = all_countries, bylayer = false, spatialslices = true, skipmissing = false, threaded = false)

# Finally, if you return a named tuple from your zonal function, zonal will automatically
# construct a RasterStack for you.
@time zonal(precip_cellarea_stack; of = all_countries, bylayer = false, spatialslices = true, skipmissing = false, threaded = false) do stack
    return (; precip = sum(skipmissing(stack.precip)), cellarea = sum(skipmissing(stack.cellarea)))
end

f1(stack) = (; precip = sum(skipmissing(stack.precip)), cellarea = sum(skipmissing(stack.cellarea)))
s1 = @time zonal(f1, precip_cellarea_stack; of = all_countries, bylayer = false, spatialslices = true, skipmissing = false, threaded = true)
s2 = @time zonal(sum ∘ skipmissing, precip_cellarea_stack; of = all_countries, bylayer = true, spatialslices = true, skipmissing = false, threaded = true)

all(map(==, s1, s2)) # true - => bylayer is not changing the result
```