### PR TITLE
Benchmark using map in zonal

### DIFF
--- a/benchmarks/methods/zonal.jl
+++ b/benchmarks/methods/zonal.jl
@@ -1,0 +1,12 @@
+using Rasters, RasterDataSources, ArchGDAL, NaturalEarth
+
+precip = cat((Raster(WorldClim{Climate}, :prec; month = i) for i in 1:12)...; dims = Ti)
+all_countries = naturalearth("admin_0_countries", 10)
+
+
+@be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $false) seconds=5
+@be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $(Rasters.ByMap(false))) seconds=5
+
+
+@be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $true) seconds=5
+@be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $(Rasters.ByMap(true))) seconds=5

--- a/benchmarks/methods/zonal.jl
+++ b/benchmarks/methods/zonal.jl
@@ -3,10 +3,9 @@ using Rasters, RasterDataSources, ArchGDAL, NaturalEarth
 precip = cat((Raster(WorldClim{Climate}, :prec; month = i) for i in 1:12)...; dims = Ti)
 all_countries = naturalearth("admin_0_countries", 10)
 
-
 @be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $false) seconds=5
-@be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $(Rasters.ByMap(false))) seconds=5
+@be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $(Rasters._ByMap(false))) seconds=5
 
 
 @be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $true) seconds=5
-@be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $(Rasters.ByMap(true))) seconds=5
+@be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $(Rasters._ByMap(true))) seconds=5

--- a/src/methods/zonal.jl
+++ b/src/methods/zonal.jl
@@ -125,7 +125,7 @@ function _zonal(f, x::RasterStackOrArray, ::Nothing, data;
             zs[i] = _zonal(f, x, geoms[i]; kw...)
         end
         return zs
-    elseif threaded isa ByMap
+    elseif threaded isa _ByMap
         return _zonal_via_map(f, x, geoms; progress, threaded = threaded.threaded, kw...)
     else
         throw(ArgumentError("threaded must be true, false or `ByMap([true/false])`"))
@@ -156,8 +156,8 @@ end
 _maybe_skipmissing_call(f, A, sm) = sm ? f(skipmissing(A)) : f(A)
 
 
-struct ByMap
-    threaded::Bool
+struct _ByMap{T}
+    threaded::T
 end
 
 function _zonal_via_map(f, x, geoms; progress, threaded, kw...)


### PR DESCRIPTION
`alloc_zonal` is a huge headache to work with if we make zonal more complex.  This PR allows a switch to using `map` or a GeometryOps `maptasks` like approach on the type of `threaded`.

This will allow us to experiment and see whether it's worth it to switch to `map` and friends!

## Single threaded

~5% faster to use map than alloc_zonal

```julia
julia> @be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $false) seconds=5
Benchmark: 58 samples with 1 evaluation
 min    81.071 ms (226529 allocs: 31.661 MiB, 1.62% gc time)
 median 85.743 ms (226529 allocs: 31.661 MiB, 4.08% gc time)
 mean   87.544 ms (226529 allocs: 31.661 MiB, 4.39% gc time)
 max    135.531 ms (226529 allocs: 31.661 MiB, 8.35% gc time)

julia> @be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $(Rasters.ByMap(false))) seconds=5
Benchmark: 61 samples with 1 evaluation
 min    76.770 ms (213692 allocs: 30.771 MiB, 1.63% gc time)
 median 81.404 ms (213692 allocs: 30.771 MiB, 3.41% gc time)
 mean   82.221 ms (213692 allocs: 30.771 MiB, 4.03% gc time)
 max    134.314 ms (213692 allocs: 30.771 MiB, 6.76% gc time)
```

## Multi threaded (8 threads)

7% faster to use map

```julia
julia> @be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $true) seconds=5
Benchmark: 115 samples with 1 evaluation
 min    38.700 ms (226575 allocs: 31.667 MiB, 3.50% gc time)
 median 41.393 ms (226575 allocs: 31.667 MiB, 6.97% gc time)
 mean   41.937 ms (226575.04 allocs: 31.667 MiB, 7.21% gc time)
 max    60.161 ms (226580 allocs: 31.667 MiB, 10.60% gc time)

julia> @be zonal($sum, $(precip[Ti(1)]); of = $countries, progress = $false, threaded = $(Rasters.ByMap(true))) seconds=5
Benchmark: 126 samples with 1 evaluation
 min    32.727 ms (213958 allocs: 30.813 MiB)
 median 37.612 ms (213958 allocs: 30.813 MiB, 7.60% gc time)
 mean   37.835 ms (213958.01 allocs: 30.813 MiB, 7.31% gc time)
 max    58.490 ms (213959 allocs: 30.813 MiB, 11.72% gc time)
```