### PR TITLE
remove unnecessary `replace_missing` in spatial means tutorial

### DIFF
--- a/docs/src/tutorials/spatial_mean.md
+++ b/docs/src/tutorials/spatial_mean.md
@@ -163,11 +163,10 @@ GCMs = Dim{:gcm}([GFDL_ESM4, IPSL_CM6A_LR]) # These are different general circul
 precip_future = (@d getfutureprec.(SSPs, GCMs)) |> RasterSeries |> Rasters.combine
 ````
 
-Since the format of WorldClim's datasets for future climate is slightly different from the dataset for the historical period, this actually returned a 5-dimensional raster, with a `Band` dimension that represents months. Here we'll just select the 6th month, matching the selection above (but note that the analysis would also work for all Bands simultaneously). We will also replace the `NaN` missing value by the more standard `missing` using [`replace_missing`](@ref). 
+Since the format of WorldClim's datasets for future climate is slightly different from the dataset for the historical period, this actually returned a 5-dimensional raster, with a `Band` dimension that represents months. Here we'll just select the 6th month, matching the selection above (but note that the analysis would also work for all Bands simultaneously).
 
 ````@example cellarea
 precip_future = precip_future[Band = 6]
-precip_future = replace_missing(precip_future)
 ````
 
 On our 4-dimensional raster, functions like `crop` and `mask`, as well as broadcasting, will still work.


### PR DESCRIPTION
CDM now takes care of converting missing values.