### PR TITLE
Fix missing return arg in edge burning

### DIFF
--- a/src/methods/burning/edges.jl
+++ b/src/methods/burning/edges.jl
@@ -102,7 +102,7 @@ end
 
     GI.npoint(geom) > 0 || return edge_count, max_ylen, min_y
     xlookup, ylookup = lookup(dims, (X(), Y())) 
-    (length(xlookup) > 0 && length(ylookup) > 0) || return edge_count, max_ylen
+    (length(xlookup) > 0 && length(ylookup) > 0) || return edge_count, max_ylen, min_y
 
     # Raster properties
     starts = (Float64(first(xlookup)), Float64(first(ylookup)))


### PR DESCRIPTION
Internal function returned 2 tuple instead of 3 only on a branch of the conditional and caused issues for me, which this seems to have fixed