### PR TITLE
Make sure `open` is always called in aggregate

### DIFF
--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -270,6 +270,7 @@ gdalpath = maybedownload(url)
         @testset "aggregate" begin
             ag = aggregate(mean, gdalarray, 4)
             @test ag == aggregate(mean, gdalarray, (X(4), Y(4)))
+            @test ag == aggregate(mean, lazyarray, (X(4), Y(4)))
             @test ag == aggregate(mean, lazyarray, 4; filename=tempname() * ".tif")
             @time ag_disk = aggregate(mean, lazyarray, 4; filename=tempname() * ".tif")
             @test ag_disk == ag


### PR DESCRIPTION
This makes it such that the `src` is first opened and then cached.  Also changed 2 variable names to enhance readability.  The method directly below does the same thing so I think this is reasonable.

Someone should probably add a test.  But at least locally this fixes #1020 for me.