### PR TITLE
Range extremes computation leads to numerical precision bugs

### DIFF
--- a/ext/RastersArchGDALExt/gdal_source.jl
+++ b/ext/RastersArchGDALExt/gdal_source.jl
@@ -158,32 +158,20 @@ function RA._dims(raster::AG.RasterDataset, crs=nokw, mappedcrs=nokw)
         xstep = gt[GDAL_WE_RES]
         ystep = gt[GDAL_NS_RES] # Usually a negative number
         # Get min, max and sampling depending on AREA_OR_POINT
-        if _gdalmetadata(raster.ds, "AREA_OR_POINT") == "Point"
-            sampling = Points()
-            xmin, xmax = gt[GDAL_TOPLEFT_X], gt[GDAL_TOPLEFT_X] + xstep * (xsize - 1)
-            ymax = gt[GDAL_TOPLEFT_Y]
-            ymin = gt[GDAL_TOPLEFT_Y] + ystep * (ysize - 1)
+        xmin = gt[GDAL_TOPLEFT_X]
+        ymax = gt[GDAL_TOPLEFT_Y]
+        sampling = if _gdalmetadata(raster.ds, "AREA_OR_POINT") == "Point"
+            Points()
         else
-            # GeoTiff uses the "pixelCorner" convention
-            sampling = Intervals(GDAL_LOCUS)
-            xmin, xmax = if xstep > 0
-                gt[GDAL_TOPLEFT_X], gt[GDAL_TOPLEFT_X] + xstep * (xsize - 1)
-            else
-                gt[GDAL_TOPLEFT_X] + xstep, gt[GDAL_TOPLEFT_X] + xstep * xsize
-            end
-            ymax, ymin = if ystep > 0
-                gt[GDAL_TOPLEFT_Y], gt[GDAL_TOPLEFT_Y] + ystep * (ysize - 1)
-            else
-                gt[GDAL_TOPLEFT_Y] + ystep, gt[GDAL_TOPLEFT_Y] + ystep * ysize
-            end
+            Intervals(GDAL_LOCUS)
         end
 
         # Define order
         xorder = xstep > 0 ? ForwardOrdered() : ReverseOrdered()
         yorder = ystep > 0 ? ForwardOrdered() : ReverseOrdered()
         # Create lookup index. LinRange is easiest always the right size after fp error
-        xindex = range(; start=xmin, stop=xmax, length=xsize)
-        yindex = range(; start=ymax, stop=ymin, length=ysize)
+        xindex = range(; start=xmin, step=xstep, length=xsize)
+        yindex = range(; start=ymax, step=ystep, length=ysize)
 
         # Define `Projected` lookups fo X and Y dimensions
         xlookup = Projected(xindex;

--- a/src/methods/aggregate.jl
+++ b/src/methods/aggregate.jl
@@ -271,8 +271,7 @@ function disaggregate(lookup::Lookup, scale)
     len = length(lookup) * intscale
     step_ = step(lookup) / intscale
     start = lookup[1] - _agoffset(Start(), intscale) * step_
-    stop = start + (len - 1)  * step_
-    index = LinRange(start, stop, len)
+    index = range(; start=start, step=step_, length=len)
     if lookup isa AbstractSampled
         sp = disaggregate(locus, span(lookup), intscale)
         return rebuild(lookup; data=index, span=sp)

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -79,8 +79,8 @@ function _dims(A::RasterDiskArray{GRDsource}, crs=nokw, mappedcrs=nokw)
     # Not fully implemented yet
     xy_metadata = _metadatadict(GRDsource())
 
-    xindex = range(; start=xbounds[1], stop=xbounds[2] - xspan, length=xsize)
-    yindex = range(; start=ybounds[2] + yspan, stop=ybounds[1], length=ysize)
+    xindex = range(; start=xbounds[1], step=xspan, length=xsize)
+    yindex = range(; start=ybounds[2] + yspan, step=yspan, length=ysize)
 
     xlookup = Projected(xindex;
         order=GRD_X_ORDER,


### PR DESCRIPTION
While working with a high-resolution GeoTIFF DEM (GMTED 7.5"), I noticed that the coordinate steps retrieved via RasterStack("dem.tif", lazy=true) exhibit slight floating-point imprecision in the final decimal places. Interestingly, both gdalinfo and ArchGDAL report these values correctly.

Upon investigation, I identified a snippet in the RastersArchGDALExt extension that likely introduces these numerical deltas. Currently, the dimension range is recomputed using start, end, and count. Because the end value is derived from a multiplication step, it introduces small errors compared to using start, step, and count—which are the raw input factors.

https://github.com/rafaqz/Rasters.jl/blob/3ba72770c1d8aab8edb1b124e151baeb1d660ef2/ext/RastersArchGDALExt/gdal_source.jl#L161-L179

I have prepared a pull request to address this, along with two other instances of the same pattern found within the codebase.

Note on Coordinate Offsets:
I have proceeded under the assumption that ArchGDAL consistently provides the Upper Left corner coordinates (as per the GDAL geotransform standard).