### PR TITLE
Revise Get Started and tutorial pages for clarity

### DIFF
--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-In a script or notebook, install Rasters.jl and other packages used in this tutorial:
+Install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -92,7 +92,7 @@ with an `Array`. `view` is always lazy, and reads from disk are deferred until
 The next example uses some real world data. To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
 
 ````julia
-ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path goes here
+ENV["RASTERDATASOURCES_PATH"] = joinpath(homedir(), "RasterDataSources") # or "/your/path/here"
 ````
 
 Use the `..` selector to take a view of Madagascar:
@@ -100,7 +100,6 @@ Use the `..` selector to take a view of Madagascar:
 ````@example first_raster
 import ArchGDAL
 using Rasters, RasterDataSources
-const RS = Rasters
 using CairoMakie
 CairoMakie.activate!()
 

--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -2,24 +2,11 @@
 
 ## Installation
 
-Install Rasters.jl by entering the Julia REPL package mode (press `]`) and type 
-
-````julia
-add Rasters
-````
-
-or from a script/notebook:
+In a script or notebook, install Rasters.jl and other packages used in this tutorial:
 
 ````julia
 using Pkg
-Pkg.add("Rasters")
-````
-
-This tutorial also uses the following packages, which you can install the same way:
-
-
-````julia
-Pkg.add(["Dates", "RasterDataSources", "CairoMakie", "ArchGDAL"])
+Pkg.add(["Rasters", "Dates", "RasterDataSources", "CairoMakie", "ArchGDAL"])
 ````
 
 ## Creating a Raster

--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -1,21 +1,31 @@
 # Quick start
 
-## Install the package by typing:
+## Installation
+
+Install Rasters.jl by entering the Julia REPL package mode (press `]`) and type 
 
 ````julia
-] 
 add Rasters
 ````
 
-then do
+or from a script/notebook:
 
 ````julia
-using Rasters
+using Pkg
+Pkg.add("Rasters")
 ````
 
+This tutorial also uses the following packages, which you can install the same way:
+
+
+````julia
+Pkg.add(["Dates", "RasterDataSources", "CairoMakie", "ArchGDAL"])
+````
+
+## Creating a Raster
+
 Using Rasters to read GeoTiff or NetCDF files will output something similar to the following toy examples.
-This is possible because Rasters.jl extends DimensionalData.jl so that spatial data can be indexed using
-named dimensions like `X`, `Y` and `Ti` (time) and e.g. spatial coordinates.
+This is possible because Rasters.jl extends [DimensionalData.jl](https://rafaqz.github.io/DimensionalData.jl/stable/) so that spatial data can be indexed using named dimensions like `X` and `Y` (coordinates) and `Ti` (time).
 
 ````@example first_raster
 using Rasters, Dates
@@ -27,40 +37,47 @@ ras = Raster(rand(lon, lat, ti)) # this generates random numbers with the dimens
 
 ## Getting the lookup array from dimensions
 
+Lookups are ranges assigned to each dimension axis, letting us refer to data within our Raster by its real-world values (like longitude, latitude, or time) instead of integer index positions. 
+
 ````@example first_raster
 lon = lookup(ras, X) # if X is longitude
 lat = lookup(ras, Y) # if Y is latitude
 ````
 
+!!! info "Dimensions"
+      Rasters uses X, Y, and Z dimensions from [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/) to represent spatial directions like longitude,
+      latitude and the vertical dimension, and subset data with them. Ti is used for time, and Band represents bands.
+      Other dimensions can have arbitrary names, but will be treated generically.
+      See [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/) for more details on how they work.
+
+
+
 ## Select by index
-Selecting a time slice by index is done via
+
+Select a time slice by its integer index: 
+
 ````@example first_raster
 ras[Ti(1)]
 ````
-also
+The same slice can also be selected with keyword syntax:
 
 ````@example first_raster
 ras[Ti=1]
 ````
 
-or and interval of indices using the syntax =a:b or (a:b)
+A range of indices can also be selected using the syntax `= a:b` or `(a:b)`:
+
 ````@example first_raster
 ras[Ti(1:10)]
 ````
+
 ## Select by value
+
+Instead of integer positions, we can select using the actual coordinate values with `At`:
 
 ````@example first_raster
 ras[Ti=At(DateTime(2001))]
 ````
-
-More options are available, like `Near`, `Contains` and `Where`.
-
-!!! info "Dimensions"
-      Rasters uses X, Y, and Z dimensions from [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/) to represent spatial directions like longitude,
-      latitude and the vertical dimension, and subset data with them. Ti is used for time, and Band represent bands.
-      Other dimensions can have arbitrary names, but will be treated generically.
-      See [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/) for more details on how they work.
-
 
 !!! info "Lookup Arrays"
      These specify properties of the index associated with e.g. the X and Y
@@ -69,14 +86,13 @@ More options are available, like `Near`, `Contains` and `Where`.
      another projection like `EPSG(4326)`. `Mapped` is largely designed to handle
      NetCDF dimensions, especially with `Explicit` spans.
 
-
 ## Subsetting an object
 
-Regular `getindex` (e.g. `A[1:100, :]`) and `view` work on all objects just as
+Regular `getindex` (e.g. `A[1:100, :]`) and `view` work on all objects, just as
 with an `Array`. `view` is always lazy, and reads from disk are deferred until
-`getindex` is used. `DimensionalData.jl` `Dimension`s and `Selector`s are the other
-way to subset an object, making use of the objects index to find values at 
-e.g. certain `X/Y` coordinates. The available selectors are listed here:
+`getindex` is used. 
+
+[`DimensionalData.jl`](https://rafaqz.github.io/DimensionalData.jl/stable/)'s `Dimension`s and `Selector`s are another way to subset an object, using the object's lookups to find values at specific `X/Y` coordinates (or any other dimensions). The available selectors are listed here:
 
 | Selectors |              Description                                                           |
 | :--------------------- | :----------------------------------------------------------------- |
@@ -86,10 +102,16 @@ e.g. certain `X/Y` coordinates. The available selectors are listed here:
 | `a..b`/`Between(a, b)` | get all indices between two values, excluding the high value.      |
 | `Contains(x)`          | get indices where the value x falls within an interval.            |
 
-!!! info
-      - Use the `..` selector to take a view of madagascar:
+The next example uses some real world data. To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
+
+````julia
+ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path goes here
+````
+
+Use the `..` selector to take a view of Madagascar:
 
 ````@example first_raster
+import ArchGDAL
 using Rasters, RasterDataSources
 const RS = Rasters
 using CairoMakie

--- a/docs/src/tutorials/array_operations.md
+++ b/docs/src/tutorials/array_operations.md
@@ -6,13 +6,7 @@ that take a `dims` argument can also use the dimension name.
 
 ## Setup
 
-Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
-
-```julia
-add Rasters Statistics RasterDataSources
-```
-
-or from a script/notebook: 
+In a script or notebook, install the packages used in this tutorial:
 
 ````julia
 using Pkg

--- a/docs/src/tutorials/array_operations.md
+++ b/docs/src/tutorials/array_operations.md
@@ -4,6 +4,28 @@ Most base methods work as for regular julia `Array`s, such as `reverse` and
 rotations like `rotl90`. Base, statistics and linear algebra methods like `mean`
 that take a `dims` argument can also use the dimension name. 
 
+## Setup
+
+Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
+
+```julia
+add Rasters Statistics RasterDataSources
+```
+
+or from a script/notebook: 
+
+````julia
+using Pkg
+Pkg.add(["Rasters", "Statistics", "RasterDataSources"])
+````
+
+To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
+
+````julia
+ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+````
+
+
 ## Mean over the time dimension:
 
 ````@example operations

--- a/docs/src/tutorials/array_operations.md
+++ b/docs/src/tutorials/array_operations.md
@@ -6,7 +6,7 @@ that take a `dims` argument can also use the dimension name.
 
 ## Setup
 
-In a script or notebook, install the packages used in this tutorial:
+Install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -16,7 +16,7 @@ Pkg.add(["Rasters", "Statistics", "RasterDataSources"])
 To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
 
 ````julia
-ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+ENV["RASTERDATASOURCES_PATH"] = joinpath(homedir(), "RasterDataSources") # or "/your/path/here"
 ````
 
 

--- a/docs/src/tutorials/crazy_rasterization.md
+++ b/docs/src/tutorials/crazy_rasterization.md
@@ -11,13 +11,7 @@ array of integers, which stores the index of each geometry that touches the pixe
 
 ## Setup
 
-Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
-
-```julia
-add NaturalEarth CairoMakie Rasters
-```
-
-or from a script/notebook: 
+In a script or notebook, install the packages used in this tutorial:
 
 ````julia
 using Pkg

--- a/docs/src/tutorials/crazy_rasterization.md
+++ b/docs/src/tutorials/crazy_rasterization.md
@@ -11,7 +11,7 @@ array of integers, which stores the index of each geometry that touches the pixe
 
 ## Setup
 
-In a script or notebook, install the packages used in this tutorial:
+Install the packages used in this tutorial:
 
 ````julia
 using Pkg

--- a/docs/src/tutorials/crazy_rasterization.md
+++ b/docs/src/tutorials/crazy_rasterization.md
@@ -9,7 +9,22 @@ where two countries overlap, you want to save the indices of both countries.
 A simple way to do this is to have each pixel of the raster actually be an
 array of integers, which stores the index of each geometry that touches the pixel.
 
-First, let's get some data.  This is a feature collection of all countries in the world.
+## Setup
+
+Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
+
+```julia
+add NaturalEarth CairoMakie Rasters
+```
+
+or from a script/notebook: 
+
+````julia
+using Pkg
+Pkg.add(["NaturalEarth", "CairoMakie", "Rasters"])
+````
+
+Now, let's get some data.  This is a feature collection of all countries in the world.
 
 ```@example crazy
 using NaturalEarth: naturalearth

--- a/docs/src/tutorials/gbif_wflow.md
+++ b/docs/src/tutorials/gbif_wflow.md
@@ -6,7 +6,7 @@ It uses GBIF and WorldClim data, which are common datasets in ecology. We'll loa
 
 ## Setup
 
-In a script or notebook, install the packages used in this tutorial:
+Install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -16,7 +16,7 @@ Pkg.add(["Rasters", "GBIF2", "RasterDataSources", "ArchGDAL", "CairoMakie", "CSV
 To download the data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
 
 ````julia
-ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+ENV["RASTERDATASOURCES_PATH"] = joinpath(homedir(), "RasterDataSources") # or "/your/path/here"
 ````
 
 ## Load Rasters, ArchGDAL, RasterDataSources and GBIF

--- a/docs/src/tutorials/gbif_wflow.md
+++ b/docs/src/tutorials/gbif_wflow.md
@@ -4,6 +4,27 @@ This example shows a full Species distribution modelling workflow, from loading 
 
 It uses GBIF and WorldClim data, which are common datasets in ecology. We'll load occurrences for the Mountain Pygmy Possum species using [GBIF2.jl](https://github.com/rafaqz/GBIF2.jl), an interface to the [Global Biodiversity Information Facility](https://www.gbif.org/), and extract environmental variables using BioClim data from [RasterDataSources.jl](https://github.com/EcoJulia/RasterDataSources.jl).
 
+## Setup
+
+Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
+
+```julia
+add Rasters GBIF2 RasterDataSources ArchGDAL CairoMakie CSV DataFrames Maxnet MLJGLMInterface SpeciesDistributionModels
+```
+
+or from a script/notebook: 
+
+````julia
+using Pkg
+Pkg.add(["Rasters", "GBIF2", "RasterDataSources", "ArchGDAL", "CairoMakie", "CSV", "DataFrames", "Maxnet", "MLJGLMInterface", "SpeciesDistributionModels"])
+````
+
+To download the data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
+
+````julia
+ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+````
+
 ## Load Rasters, ArchGDAL, RasterDataSources and GBIF
 The GBIF2 library is used to download occurrence data, RasterDataSources to conveniently access Bioclim data. ArchGDAL is necessary to load in the Bioclim data.
 

--- a/docs/src/tutorials/gbif_wflow.md
+++ b/docs/src/tutorials/gbif_wflow.md
@@ -6,13 +6,7 @@ It uses GBIF and WorldClim data, which are common datasets in ecology. We'll loa
 
 ## Setup
 
-Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
-
-```julia
-add Rasters GBIF2 RasterDataSources ArchGDAL CairoMakie CSV DataFrames Maxnet MLJGLMInterface SpeciesDistributionModels
-```
-
-or from a script/notebook: 
+In a script or notebook, install the packages used in this tutorial:
 
 ````julia
 using Pkg

--- a/docs/src/tutorials/plot_makie.md
+++ b/docs/src/tutorials/plot_makie.md
@@ -1,3 +1,26 @@
+# Rasters with Makie.jl
+
+## Setup
+
+Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
+
+```julia
+add Rasters CairoMakie Makie RasterDataSources ArchGDAL
+```
+
+or from a script/notebook: 
+
+````julia
+using Pkg
+Pkg.add(["Rasters", "CairoMakie", "Makie", "RasterDataSources", "ArchGDAL"])
+````
+
+To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
+
+````julia
+ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+````
+
 ## Plotting in Makie
 
 Plotting in Makie works somewhat differently than Plots, since the recipe system is different.
@@ -6,10 +29,13 @@ or even surface for a 3D plot) with ease.
 
 ## 2-D rasters in Makie
 
+We'll start with a single 2-D raster: BioClim variable 5 from the WorldClim dataset, which is the maximum temperature of the warmest month (in °C) on a global grid. 
+
+
 ````@example makie
 using CairoMakie, Makie
 using Rasters, RasterDataSources, ArchGDAL
-A = Raster(WorldClim{BioClim}, 5) # this is a 3D raster, so is not accepted.
+A = Raster(WorldClim{BioClim}, 5)
 ````
 
 ````@example makie
@@ -17,7 +43,7 @@ fig, ax, _ = plot(A)
 contour(fig[1, 2], A)
 ax = Axis(fig[2, 1]; aspect = DataAspect())
 contourf!(ax, A)
-surface(fig[2, 2], A) # even a 3D plot work!
+surface(fig[2, 2], A; axis = (type = LScene,)) # even a 3D plot works!
 fig
 ````
 
@@ -39,8 +65,9 @@ You can pass any theming keywords in, which are interpreted by Makie appropriate
 
 ### Plotting with `Observable`s, animations
 
-`Rasters.rplot` should support Observable input out of the box, but the dimensions of that input
-must remain the same - i.e., the element names of a RasterStack must remain the same.
+An `Observable` is a container object whose stored value you can update interactively. You can create functions or other observables that are executed whenever an observable changes. This is how Makie supports interactive and animated plots. 
+
+`Rasters.rplot` should support Observable input out of the box, but the dimensions of that input must remain the same - i.e., the element names of a RasterStack must remain the same.
 
 ````@example makie
 # `stack` is the WorldClim climate data for January
@@ -67,18 +94,24 @@ Rasters.rplot
 
 ## Using vanilla Makie
 
+So far we've leaned on Rasters' Makie recipes, which take a raster directly and set up the axes and layout for us. For full control over the figure, we can instead build the scaffolding manually.
+
 ````@example makie
 using Rasters, RasterDataSources
 ````
-The data
-````@example makie
-layers = (:evenness, :range, :contrast, :correlation)
-st = RasterStack(EarthEnv{HabitatHeterogeneity}, layers)
-ausbounds = X(100 .. 160), Y(-50 .. -10) # Roughly cut out australia
-aus = st[ausbounds...] |> Rasters.trim
-````
+The data:
 
-The plot
+````@example makie
+layers = (:evenness, :range, :contrast, :correlation) # tuple of the four variable names from HabitatHeterogeneity we want to use
+st = RasterStack(EarthEnv{HabitatHeterogeneity}, layers) # load the four layers together as a RasterStack
+ausbounds = X(100 .. 160), Y(-50 .. -10) # Roughly cut out Australia using the .. selector from DimensionalData.jl
+aus = st[ausbounds...] |> Rasters.trim # crop to the bounds, then trim away the empty (missing) edge rows/columns
+````
+!!! note
+      Rasters extends [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/)'s `DimArray` and `DimStack` to build `Raster` and `RasterStack` objects, and uses its selectors such as `..`
+
+The plot:
+
 ````@example makie
 # colorbar attributes
 colormap = :batlow

--- a/docs/src/tutorials/plot_makie.md
+++ b/docs/src/tutorials/plot_makie.md
@@ -2,13 +2,7 @@
 
 ## Setup
 
-Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
-
-```julia
-add Rasters CairoMakie Makie RasterDataSources ArchGDAL
-```
-
-or from a script/notebook: 
+In a script or notebook, install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -104,11 +98,11 @@ The data:
 ````@example makie
 layers = (:evenness, :range, :contrast, :correlation) # tuple of the four variable names from HabitatHeterogeneity we want to use
 st = RasterStack(EarthEnv{HabitatHeterogeneity}, layers) # load the four layers together as a RasterStack
-ausbounds = X(100 .. 160), Y(-50 .. -10) # Roughly cut out Australia using the .. selector from DimensionalData.jl
+ausbounds = X(100 .. 160), Y(-50 .. -10) # Roughly cut out Australia using the .. selector to subset the X and Y dimensions by their lookup values
 aus = st[ausbounds...] |> Rasters.trim # crop to the bounds, then trim away the empty (missing) edge rows/columns
 ````
 !!! note
-      Rasters extends [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/)'s `DimArray` and `DimStack` to build `Raster` and `RasterStack` objects, and uses its selectors such as `..`
+      Rasters extends [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/)'s `DimArray` and `DimStack` to build `Raster` and `RasterStack` objects, and uses its selectors such as `..`, which selects a range of lookup values.
 
 The plot:
 

--- a/docs/src/tutorials/plot_makie.md
+++ b/docs/src/tutorials/plot_makie.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-In a script or notebook, install the packages used in this tutorial:
+Install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -12,7 +12,7 @@ Pkg.add(["Rasters", "CairoMakie", "Makie", "RasterDataSources", "ArchGDAL"])
 To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
 
 ````julia
-ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+ENV["RASTERDATASOURCES_PATH"] = joinpath(homedir(), "RasterDataSources") # or "/your/path/here"
 ````
 
 ## Plotting in Makie
@@ -96,13 +96,20 @@ using Rasters, RasterDataSources
 The data:
 
 ````@example makie
-layers = (:evenness, :range, :contrast, :correlation) # tuple of the four variable names from HabitatHeterogeneity we want to use
-st = RasterStack(EarthEnv{HabitatHeterogeneity}, layers) # load the four layers together as a RasterStack
-ausbounds = X(100 .. 160), Y(-50 .. -10) # Roughly cut out Australia using the .. selector to subset the X and Y dimensions by their lookup values
-aus = st[ausbounds...] |> Rasters.trim # crop to the bounds, then trim away the empty (missing) edge rows/columns
+# tuple of the four variable names from HabitatHeterogeneity we want to use
+layers = (:evenness, :range, :contrast, :correlation) 
+
+# load the four layers together as a RasterStack
+st = RasterStack(EarthEnv{HabitatHeterogeneity}, layers) 
+
+# Roughly cut out Australia using the .. selector to subset the X and Y dimensions by their lookup values
+ausbounds = X(100 .. 160), Y(-50 .. -10) 
+
+# crop to the bounds, then trim away the empty (missing) edge rows/columns
+aus = st[ausbounds...] |> Rasters.trim 
 ````
 !!! note
-      Rasters extends [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/)'s `DimArray` and `DimStack` to build `Raster` and `RasterStack` objects, and uses its selectors such as `..`, which selects a range of lookup values.
+      Rasters are also AbstractDimArrays, and therefore all [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/) indexing functionality works on Rasters objects, such as the `..` selector, which selects a range of lookup values.
 
 The plot:
 

--- a/docs/src/tutorials/plotting.md
+++ b/docs/src/tutorials/plotting.md
@@ -1,4 +1,30 @@
+# Rasters with Plots.jl 
+
+## Setup
+
+Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
+
+```julia
+add Rasters RasterDataSources ArchGDAL NCDatasets CFTime Shapefile Plots CairoMakie Statistics Downloads Dates
+```
+
+or from a script/notebook: 
+
+````julia
+using Pkg
+Pkg.add(["Rasters", "RasterDataSources", "ArchGDAL", "NCDatasets",
+         "CFTime", "Shapefile", "Plots", "CairoMakie",
+         "Statistics", "Downloads", "Dates"])
+````
+
+To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
+
+````julia
+ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+````
+
 ## Plots, simple
+
 [`Plots.jl`](https://github.com/JuliaPlots/Plots.jl) and [`Makie.jl`](https://makie.org) are fully supported by
 Rasters.jl, with recipes for plotting `Raster` and `RasterStack` provided. `plot`
 will plot a heatmap with axes matching dimension values. If `mappedcrs` is used,
@@ -12,7 +38,7 @@ It can be set manually to change the resolution (e.g. for large or high-quality 
 ````@example plots
 using Rasters, RasterDataSources, ArchGDAL
 using Plots
-import Plots: plot # hide 
+import Plots: plot 
 A = Raster(WorldClim{BioClim}, 5)
 plot(A; max_res=3000)
 ````
@@ -26,9 +52,11 @@ This is an unexported function, since we're not sure how the API will change goi
 
 ## Makie, simple
 
+Loading both Plots and Makie in the same session can cause conflicts, since both export functions with the same name, such as `plot`. To avoid this, we import Makie's names selectively (`using CairoMakie: CairoMakie, Makie`) and prefix the call as `Makie.plot`, so bare `plot` elsewhere still refers to `Plots`.
+
 ````@example plots
 using CairoMakie: CairoMakie, Makie
-CairoMakie.activate!(px_per_unit = 2) # hide
+CairoMakie.activate!(px_per_unit = 2) 
 using Rasters, RasterDataSources, ArchGDAL
 A = Raster(WorldClim{BioClim}, 5)
 Makie.plot(A)
@@ -48,11 +76,10 @@ filename = download(url, "tos_O1_2001-2002.nc");
 A = Raster(filename)
 ````
 
-Objects with Dimensions other than X and Y will produce multi-pane plots. Here we plot every third month in
-the first year in one plot:
+Objects with Dimensions other than X and Y will produce multi-pane plots. Here we plot every third month in the first year in one plot:
 
 ````@example plots
-A[Ti=1:3:12] |> plot
+A[Ti=1:3:12] |> plot # pipe result directly to plot
 ````
 
 Now plot the ocean temperatures around the Americas in the first month of 2001.
@@ -62,6 +89,7 @@ to index it with `Near`.
 
 ````@example plots
 using CFTime
+# Select the time slice nearest Jan 17 2001, within these lat/lon ranges, then plot
 A[Ti(Near(DateTime360Day(2001, 01, 17))), Y(-60.0 .. 90.0), X(45.0 .. 190.0)] |> plot 
 ````
 
@@ -72,29 +100,24 @@ Other plot functions and sliced objects that have only one `X`/`Y`/`Z` dimension
 fall back to generic DimensionalData.jl plotting, which will still correctly
 label plot axes.
 
-<!-- TODO: switch the three code blocks below back to ````@example plots once
-CFTime is fixed. `mean(A; dims=Ti)` on a CFTime-calendar time dim currently
-creates a `StepRange` whose `length` returns `Float64` (via `Dates.len`),
-which breaks `axes`/`OneTo` and aborts the docs build. -->
-
-```julia
+````@example plots
 using Statistics
 # Take the mean
 mean_tos = mean(A; dims=Ti)
-```
+````
 
 ### Plot a contour plot
 
-```julia
+````@example plots
 using Plots
 Plots.contourf(mean_tos; dpi=300, size=(800, 400))
-```
+````
 ### write to disk
 Write the mean values to disk
 
-```julia
+````@example plots
 write("mean_tos.nc", mean_tos)
-```
+````
 
 Plotting recipes in DimensionalData.jl are the fallback for Rasters.jl when the
 object doesn't have 2 `X`/`Y`/`Z` dimensions, or a non-spatial plot command is
@@ -109,11 +132,9 @@ A[Y(Near(20.0)), Ti(1)] |> plot
 In this example we will `mask` the Scandinavian countries with border polygons,
 then `mosaic` together to make a single plot. 
 
-First, get the country boundary shape files using GADM.jl.
+First, get the country boundary shape files from a URL and load them with `Shapefile.jl`.
 
-using Rasters, RasterDataSources, ArchGDAL, Shapefile, Plots, Dates, Downloads, NCDatasets
-
-## Download the shapefile
+### Download the shapefile
 ````@example plots
 using Downloads
 using Shapefile
@@ -126,6 +147,7 @@ nothing # hide
 
 ````@example plots
 shapes = Shapefile.Handle(shapefile_name)
+# Shape indices for each country (found by inspecting shapes.shapes)
 denmark_border = shapes.shapes[71]
 norway_border = shapes.shapes[53]
 sweden_border = shapes.shapes[54];
@@ -140,8 +162,9 @@ using Dates
 climate = RasterStack(WorldClim{Climate}, (:tmin, :tmax, :prec, :wind); month=July)
 ````
 
-`mask` Denmark, Norway and Sweden from the global dataset using their border polygon,
-then trim the missing values. We pad `trim` with a 10 pixel margin.
+This creates a RasterStack (an extension of [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/)'s DimStack) which holds multiple Raster layers that share the same dimensions and lookups.
+
+We define a helper function `mask_trim` that combines two operations: `mask` extracts the data within a border polygon, and `trim` removes the surrounding missing values (padded by a 10 pixel margin).
 
 ````@example plots
 mask_trim(climate, poly) = trim(mask(climate; with=poly); pad=10)
@@ -163,28 +186,30 @@ function borders!(p, poly)
 end
 ````
 
-Now we can plot the individual countries.
+Now we can plot the individual countries:
+
+Denmark,
 
 ````@example plots
 dp = plot(denmark)
 borders!(dp, denmark_border)
 ````
 
-and sweden
+and Sweden,
 
 ````@example plots
 sp = plot(sweden)
 borders!(sp, sweden_border)
 ````
 
-and norway
+and Norway.
 
 ````@example plots
 np = plot(norway)
 borders!(np, norway_border)
 ````
 
-The Norway shape includes a lot of islands. Lets crop them out using `..` intervals:
+The Norway shape includes a lot of islands. Let's crop them out using `..` intervals:
 
 ````@example plots
 norway_region = climate[X(0..40), Y(55..73)]
@@ -198,13 +223,13 @@ np = plot(norway)
 borders!(np, norway_border)
 ````
 
-Now we can combine the countries into a single raster using mosaic. first will take the first value if/when there is an overlap.
+Now we can combine the countries into a single raster using `mosaic`. When pixels overlap between countries, we take the value from the first raster in the list.
 
 ````@example plots
 scandinavia = mosaic(first, denmark, norway, sweden)
 ````
 
-And plot scandinavia, with all borders included:
+And plot Scandinavia, with all borders included:
 
 ````@example plots
 p = plot(scandinavia)
@@ -221,6 +246,6 @@ write("scandinavia.nc", scandinavia)
 write("scandinavia.tif", scandinavia)
 ````
 
-`Rasters.jl` provides a range of other methods that are being added to over time. Where applicable these methods
+`Rasters.jl` provides a range of other methods that are being added to over time. Where applicable, these methods
 read and write lazily to and from disk-based arrays of common raster file types. These methods also work for
 entire RasterStacks and RasterSeries using the same syntax.

--- a/docs/src/tutorials/plotting.md
+++ b/docs/src/tutorials/plotting.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-In a script or notebook, install the packages used in this tutorial:
+Install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -14,7 +14,7 @@ Pkg.add(["Rasters", "RasterDataSources", "ArchGDAL", "NCDatasets",
 To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
 
 ````julia
-ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+ENV["RASTERDATASOURCES_PATH"] = joinpath(homedir(), "RasterDataSources") # or "/your/path/here"
 ````
 
 ## Plots, simple
@@ -158,7 +158,7 @@ using Dates
 climate = RasterStack(WorldClim{Climate}, (:tmin, :tmax, :prec, :wind); month=July)
 ````
 
-This creates a RasterStack (an extension of [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/)'s DimStack) which holds multiple Raster layers that share the same dimensions and lookups.
+This creates a RasterStack - which is also an AbstractDimStack from [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/) - and holds multiple Raster layers that share the same dimensions and lookups.
 
 We define a helper function `mask_trim` that combines two operations: `mask` extracts the data within a border polygon, and `trim` removes the surrounding missing values (padded by a 10 pixel margin).
 
@@ -191,7 +191,7 @@ dp = plot(denmark)
 borders!(dp, denmark_border)
 ````
 
-and Sweden,
+Sweden,
 
 ````@example plots
 sp = plot(sweden)

--- a/docs/src/tutorials/plotting.md
+++ b/docs/src/tutorials/plotting.md
@@ -2,13 +2,7 @@
 
 ## Setup
 
-Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
-
-```julia
-add Rasters RasterDataSources ArchGDAL NCDatasets CFTime Shapefile Plots CairoMakie Statistics Downloads Dates
-```
-
-or from a script/notebook: 
+In a script or notebook, install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -86,6 +80,8 @@ Now plot the ocean temperatures around the Americas in the first month of 2001.
 Notice we are using lat/lon coordinates and date/time instead of regular
 indices. The time dimension uses `DateTime360Day`, so we need to load CFTime.jl
 to index it with `Near`.
+
+We use the `..` selector from [`DimensionalData`](https://rafaqz.github.io/DimensionalData.jl/stable/), which selects all indices between two lookup values, excluding the high value.
 
 ````@example plots
 using CFTime

--- a/docs/src/tutorials/resample.md
+++ b/docs/src/tutorials/resample.md
@@ -47,6 +47,25 @@ and is generally pretty robust.  However, it has the following limitations:
 
 ### `resolution`, `size` and `methods`
 
+Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
+
+```julia
+add Rasters RasterDataSources ArchGDAL DimensionalData NaNStatistics CairoMakie
+```
+
+or from a script/notebook: 
+
+````julia
+using Pkg
+Pkg.add(["Rasters", "RasterDataSources", "ArchGDAL", "DimensionalData", "NaNStatistics", "CairoMakie"])
+````
+
+To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
+
+````julia
+ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+````
+
 Let's start by loading the necessary packages:
 
 ````@example resample

--- a/docs/src/tutorials/resample.md
+++ b/docs/src/tutorials/resample.md
@@ -47,13 +47,7 @@ and is generally pretty robust.  However, it has the following limitations:
 
 ### `resolution`, `size` and `methods`
 
-Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
-
-```julia
-add Rasters RasterDataSources ArchGDAL DimensionalData NaNStatistics CairoMakie
-```
-
-or from a script/notebook: 
+In a script or notebook, install the packages used in this tutorial:
 
 ````julia
 using Pkg

--- a/docs/src/tutorials/resample.md
+++ b/docs/src/tutorials/resample.md
@@ -201,7 +201,7 @@ and, how does this looks like?
 ````@example resample
 fig, ax, plt = heatmap(ras_sin)
 Colorbar(fig[1,2], plt)
-fig
+heatmap(ras_sin)
 ````
 
 now, let's go back to `latitude` and `longitude` and reduce the resolution

--- a/docs/src/tutorials/resample.md
+++ b/docs/src/tutorials/resample.md
@@ -47,7 +47,7 @@ and is generally pretty robust.  However, it has the following limitations:
 
 ### `resolution`, `size` and `methods`
 
-In a script or notebook, install the packages used in this tutorial:
+Install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -57,7 +57,7 @@ Pkg.add(["Rasters", "RasterDataSources", "ArchGDAL", "DimensionalData", "NaNStat
 To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
 
 ````julia
-ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+ENV["RASTERDATASOURCES_PATH"] = joinpath(homedir(), "RasterDataSources") # or "/your/path/here"
 ````
 
 Let's start by loading the necessary packages:
@@ -199,8 +199,6 @@ nansum(ras_m), nansum(ras_sin)
 and, how does this looks like?
 
 ````@example resample
-fig, ax, plt = heatmap(ras_sin)
-Colorbar(fig[1,2], plt)
 heatmap(ras_sin)
 ````
 
@@ -225,9 +223,7 @@ locus_resampled = DimensionalData.shiftlocus(Center(), ras_epsg)
 
 
 ````@example resample
-fig, ax, plt = heatmap(ras_epsg)
-Colorbar(fig[1,2], plt)
-fig
+heatmap(ras_epsg)
 ````
 
 ### A `Raster` from scratch
@@ -260,9 +256,7 @@ This requires that you run `using Rasters.Lookups`, where the `Intervals` and `S
 and take a look
 
 ````@example resample
-fig, ax, plt = heatmap(ras_scratch)
-Colorbar(fig[1,2], plt)
-fig
+heatmap(ras_scratch)
 ````
 
 and the corresponding resampled projection
@@ -272,9 +266,7 @@ ras_sin_s = resample(ras_scratch; size=(1440,720), crs=SINUSOIDAL_CRS, method="a
 ````
 
 ````@example resample
-fig, ax, plt = heatmap(ras_sin_s)
-Colorbar(fig[1,2], plt)
-fig
+heatmap(ras_sin_s)
 ````
 
 and go back from `sin` to `epsg`:
@@ -283,9 +275,7 @@ and go back from `sin` to `epsg`:
 ras_epsg = resample(ras_sin_s; size=(1440,720), crs=EPSG(4326), method="average")
 locus_resampled = DimensionalData.shiftlocus(Center(), ras_epsg)
 
-fig, ax, plt = heatmap(locus_resampled)
-Colorbar(fig[1,2], plt)
-fig
+heatmap(locus_resampled)
 ````
 
 and compare the total counts again!

--- a/docs/src/tutorials/spatial_mean.md
+++ b/docs/src/tutorials/spatial_mean.md
@@ -14,7 +14,7 @@ Let's get the rainfall over Chile, and compute the average rainfall across the c
 
 ## Setup
 
-In a script or notebook, install the packages used in this tutorial:
+Install the packages used in this tutorial:
 
 ````julia
 using Pkg
@@ -24,7 +24,7 @@ Pkg.add(["Rasters", "Proj", "ArchGDAL", "RasterDataSources", "NaturalEarth", "Ca
 To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
 
 ````julia
-ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+ENV["RASTERDATASOURCES_PATH"] = joinpath(homedir(), "RasterDataSources") # or "/your/path/here"
 ````
 
 ## Acquiring the data

--- a/docs/src/tutorials/spatial_mean.md
+++ b/docs/src/tutorials/spatial_mean.md
@@ -14,13 +14,7 @@ Let's get the rainfall over Chile, and compute the average rainfall across the c
 
 ## Setup
 
-Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
-
-```julia
-add Rasters Proj ArchGDAL RasterDataSources NaturalEarth CairoMakie Dates
-```
-
-or from a script/notebook: 
+In a script or notebook, install the packages used in this tutorial:
 
 ````julia
 using Pkg

--- a/docs/src/tutorials/spatial_mean.md
+++ b/docs/src/tutorials/spatial_mean.md
@@ -12,6 +12,27 @@ To compute the spatial mean, you need to weight the values by the area of each c
 
 Let's get the rainfall over Chile, and compute the average rainfall across the country for the month of June.
 
+## Setup
+
+Install the required packages by entering the Julia REPL package mode (press `]`) and typing:
+
+```julia
+add Rasters Proj ArchGDAL RasterDataSources NaturalEarth CairoMakie Dates
+```
+
+or from a script/notebook: 
+
+````julia
+using Pkg
+Pkg.add(["Rasters", "Proj", "ArchGDAL", "RasterDataSources", "NaturalEarth", "CairoMakie", "Dates"])
+````
+
+To download data you will need to specify a folder to put it in. You can do this by assigning the environment variable RASTERDATASOURCES_PATH: 
+
+````julia
+ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/" # your path here
+````
+
 ## Acquiring the data
 
 We'll get the precipitation data across the globe from [WorldClim](https://www.worldclim.org/data/index.html), via [RasterDataSources.jl](https://github.com/EcoJulia/RasterDataSources.jl), and use the `month` keyword argument to get the June data.
@@ -57,11 +78,10 @@ Now, we mask the data such that any data outside the geometry is set to `missing
 
 ````@example cellarea
 masked_precip = mask(cropped_precip; with = chile)
-heatmap(masked_precip)
+heatmap(masked_precip; axis = (; title = "Precipitation (mm)"))
 ````
 
 This is a lot of missing data, but that's mainly because the Chile geometry we have encompasses the Easter Islands as well, in the middle of the Pacific.
-
 
 ```@docs; canonical=false
 cellarea


### PR DESCRIPTION
Revisions for the Get Started and 7 tutorial pages to make them easier to follow along for new users and runnable independently.

Add a package-setup block to the top of each tutorial so each can be run independently (no contingencies on previous tutorials/pages of the docs)

Add conceptual explanations and introductions of data in places that jumped straight to code for improved context.

Add comments to explain certain lines of code

Connected certain concepts to DimensionalData and linked docs for reference.

Revisions to some explanations and for typos/grammar/flow.

plotting.md: Updated code chunks that were affected by CFTime issue (fixed in v0.2.10)

plot_makie.md: Updated bottom right plot to output as 3D again

@alex-s-gardner 