### PR TITLE
Informative error when rasterizing to an Irregular lookup with undefined bounds

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -627,9 +627,30 @@ function _as_intervals(ds::Tuple)
     # Rasterization only makes sense on Sampled Intervals
     interval_dims = map(dims(ds, DEFAULT_POINT_ORDER)) do d
         l = parent(d)
-        rebuild(d, rebuild(l; sampling=Intervals(locus(l))))
+        interval_l = rebuild(l; sampling=Intervals(locus(l)))
+        _check_intervals_bounds(d, interval_l)
+        rebuild(d, interval_l)
     end
     return setdims(ds, interval_dims)
+end
+
+# An `Irregular` lookup with undefined bounds cannot be treated as `Intervals`:
+# there is no way to know where each pixel starts and stops, so selectors like
+# `Touches` compare against `nothing` bounds and fail with an opaque `MethodError`.
+# This happens when a `Raster` is built from a plain `Vector` of coordinates rather
+# than an `AbstractRange`, so point out the likely cause and fix.
+_check_intervals_bounds(d::Dimension, l::Lookup) = nothing
+function _check_intervals_bounds(d::Dimension, l::AbstractSampled)
+    if span(l) isa Irregular && any(isnothing, bounds(l))
+        throw(ArgumentError(
+            "Cannot rasterize to the $(name(d)) dimension: its lookup is `Irregular` " *
+            "with undefined bounds, so pixel intervals cannot be determined. This usually " *
+            "means the `Raster` was built from a plain `Vector` of coordinates. Use an " *
+            "`AbstractRange` (e.g. `range(first, last; length)` or `first:step:last`) so the " *
+            "lookup is `Regular`, or set an `Irregular` span with explicit `bounds`."
+        ))
+    end
+    return nothing
 end
 
 nolookup_to_sampled(A) = rebuild(A; dims=nolookup_to_sampled(dims(A)))

--- a/test/rasterize.jl
+++ b/test/rasterize.jl
@@ -489,6 +489,23 @@ end
     @test_warn "Destination is empty" rasterize!(A1[1:0, 1:0], polygon; to=A1[1:0, 1:0], fill=1, missingval=0)
 end
 
+@testset "Cant rasterize to an Irregular lookup with undefined bounds" begin
+    # A `Raster` built from a plain `Vector` of coordinates has an `Irregular` span with
+    # `nothing` bounds, so pixel intervals cannot be determined. We should get an
+    # informative `ArgumentError` rather than an opaque `MethodError`.
+    vecraster = Raster(zeros(Int, 3, 3), (X([1.0, 2.0, 3.0]), Y([1.0, 2.0, 3.0])); missingval=0)
+    @test_throws ArgumentError rasterize(polygon; to=vecraster, fill=1)
+    # A `Regular` lookup built from a range works fine.
+    rangeraster = Raster(zeros(Int, 3, 3), (X(1.0:1.0:3.0), Y(1.0:1.0:3.0)); missingval=0)
+    @test rasterize(last, polygon; to=rangeraster, fill=1) isa Raster
+    # An `Irregular` lookup with explicit bounds is also fine.
+    boundsraster = Raster(zeros(Int, 3, 3),
+        (X(Sampled([1.0, 2.0, 3.0], ForwardOrdered(), Irregular(0.5, 3.5), Intervals(Center()), NoMetadata())),
+         Y(Sampled([1.0, 2.0, 3.0], ForwardOrdered(), Irregular(0.5, 3.5), Intervals(Center()), NoMetadata())));
+        missingval=0)
+    @test rasterize(last, polygon; to=boundsraster, fill=1) isa Raster
+end
+
 @testset "coverage" begin
     @time covsum = coverage(sum, shphandle.shapes; threaded=false, res=1, scale=10)
     @time covunion = coverage(union, shphandle.shapes; threaded=false, res=1, scale=10)


### PR DESCRIPTION
## Problem

Rasterizing to a `Raster` whose lookups were built from plain `Vector`s of coordinates (rather than an `AbstractRange`) fails with an opaque error:

```julia
lon = collect(-180.0:0.1:179.9)   # Vector, not a range
lat = collect(90.0:-0.1:-90.0)
r = Raster(zeros(Int, length(lon), length(lat)), (X(lon), Y(lat)))
rasterize(last, some_polygons; to=r, fill=1, boundary=:center)
# ERROR: MethodError: no method matching isless(::Nothing, ::Float64)
```

The crash happens deep in DimensionalData's `Touches` selector (`touches(...)` does `lowsel > upperbound`). A plain-`Vector` lookup is assigned an `Irregular(nothing, nothing)` span, and once `rasterize` reinterprets the lookup as `Intervals` (via `_as_intervals`), `bounds` returns `nothing` — so pixel edges can't be computed and the comparison against `nothing` throws.

This is easy to hit in practice: any `Raster` constructed from coordinate vectors read out of a NetCDF/Zarr store (`zg["longitude"][:]`) rather than reconstructed as a range.

## Fix

`_as_intervals` now validates each spatial dimension after converting it to `Intervals`, and throws an `ArgumentError` when the span is `Irregular` with undefined bounds. The message names the offending dimension, explains the likely cause (a `Vector` lookup), and gives the fix (use an `AbstractRange`, or an `Irregular` span with explicit `bounds`):

```
ERROR: ArgumentError: Cannot rasterize to the X dimension: its lookup is `Irregular`
with undefined bounds, so pixel intervals cannot be determined. This usually means the
`Raster` was built from a plain `Vector` of coordinates. Use an `AbstractRange`
(e.g. `range(first, last; length)` or `first:step:last`) so the lookup is `Regular`,
or set an `Irregular` span with explicit `bounds`.
```

`Regular` lookups and `Irregular` lookups with explicit bounds are unaffected (verified they still rasterize correctly).

## Tests

Added a testset covering the three cases (Vector → throws, range → works, Irregular-with-bounds → works). The full `test/rasterize.jl` suite passes with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)