### PR TITLE
Use total memory for `checkmem` on macOS

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -598,7 +598,8 @@ function _checkobjmem(obj)
 end
 _checkobjmem(f, obj) = _checkmem(f, _sizeof(obj))
 
-_checkmem(f, bytes::Int) = Sys.free_memory() > bytes || _no_memory_error(f, bytes)
+# macOS `Sys.free_memory` counts only free pages, ignoring reclaimable inactive/purgeable/compressed memory
+_checkmem(f, bytes::Int) = (Sys.isapple() ? Sys.total_memory() : Sys.free_memory()) > bytes || _no_memory_error(f, bytes)
 
 function _sizeof(A::AbstractArray{T}) where T 
     if isbits(T)


### PR DESCRIPTION
macOS `Sys.free_memory()` only counts wholly-free pages (~0.08 GB on a 24 GB machine), so `checkmem` spuriously failed on almost every `read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)