### PR TITLE
Fix multipoint extract return type

### DIFF
--- a/src/methods/extract.jl
+++ b/src/methods/extract.jl
@@ -515,7 +515,7 @@ end
             _maybe_add_fields(T, props, id, coords, I)
         end
     end
-    return 1
+    return true
 end
 
 # Maybe add optional fields

--- a/test/extract.jl
+++ b/test/extract.jl
@@ -115,6 +115,21 @@ extr[2].index
     end
 end
 
+@testset "MultiPoint" begin
+    T = @NamedTuple{geometry::Union{Missing,Tuple{Float64,Float64}},test::Union{Missing,Int64}}
+    mp = GI.MultiPoint([(9.0, 0.1), (10.0, 0.2), (10.0, 0.3)])
+    # `skipmissing=false` is the default, and used to throw a TypeError here
+    @test all(extract(rast, mp) .=== T[
+        (geometry = (9.0, 0.1), test = 1)
+        (geometry = (10.0, 0.2), test = 4)
+        (geometry = (10.0, 0.3), test = missing)
+    ])
+    @test all(extract(rast, mp; skipmissing=true) .=== @NamedTuple{geometry::Tuple{Float64,Float64},test::Int64}[
+        (geometry = (9.0, 0.1), test = 1)
+        (geometry = (10.0, 0.2), test = 4)
+    ])
+end
+
 @testset "Polygons" begin
     # Extract a polygon
     T = @NamedTuple{geometry::Union{Missing,Tuple{Float64,Float64}},test::Union{Missing,Int64}}

--- a/test/extract.jl
+++ b/test/extract.jl
@@ -118,7 +118,6 @@ end
 @testset "MultiPoint" begin
     T = @NamedTuple{geometry::Union{Missing,Tuple{Float64,Float64}},test::Union{Missing,Int64}}
     mp = GI.MultiPoint([(9.0, 0.1), (10.0, 0.2), (10.0, 0.3)])
-    # `skipmissing=false` is the default, and used to throw a TypeError here
     @test all(extract(rast, mp) .=== T[
         (geometry = (9.0, 0.1), test = 1)
         (geometry = (10.0, 0.2), test = 4)


### PR DESCRIPTION
Claude found this bug and proposed this fix while I was working on a separate branch of Rasters.jl. This is a simple return type error that pops up when using multi-point geometries with `extract`. The PR adds a quick test to check that the function works as expected, and corrects the return type in `_extract_point!`.